### PR TITLE
Add server config arguments to config file. Closes #7

### DIFF
--- a/configuration.default.ini
+++ b/configuration.default.ini
@@ -1,4 +1,11 @@
+[server]
+host = 127.0.0.1
+port = 64738
+password =
+channel =
+
 [bot]
+username = botamusique
 comment = Hi, I'm here to play radio, local music or youtube/soundcloud music. Have fun !
 volume = 0.1
 admin = User1;User2; # Allow user to kill the bot

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -71,7 +71,25 @@ class MumbleBot:
             tt.daemon = True
             tt.start()
 
-        self.mumble = pymumble.Mumble(args.host, user=args.user, port=args.port, password=args.password,
+        if args.host:
+            host = args.host
+        else:
+            host = var.config.get("server", "host")
+        if args.port:
+            port = args.port
+        else:
+            port = var.config.getint("server", "port")
+        if args.password:
+            password = args.password
+        else:
+            password = var.config.get("server", "password")
+
+        if args.user:
+            user = args.user
+        else:
+            user = var.config.get("bot", "user")
+
+        self.mumble = pymumble.Mumble(host, user=user, port=port, password=password,
                                       debug=var.config.getboolean('debug', 'mumbleConnection'))
         self.mumble.callbacks.set_callback("text_received", self.message_received)
 
@@ -371,14 +389,14 @@ if __name__ == '__main__':
     parser.add_argument("-q", "--quiet", dest="quiet", action="store_true", help="Only Error logs")
 
     # Mumble arguments
-    parser.add_argument("-s", "--server", dest="host", type=str, required=True, help="The server's hostame of a mumble server")
-    parser.add_argument("-u", "--user", dest="user", type=str, required=True, help="Username you wish, Default=abot")
-    parser.add_argument("-P", "--password", dest="password", type=str, default="", help="Password if server requires one")
-    parser.add_argument("-p", "--port", dest="port", type=int, default=64738, help="Port for the mumble server")
-    parser.add_argument("-c", "--channel", dest="channel", type=str, default="", help="Default chanel for the bot")
+    parser.add_argument("-s", "--server", dest="host", type=str, help="The server's hostame of a mumble server")
+    parser.add_argument("-u", "--user", dest="user", type=str, help="Username you wish, Default=abot")
+    parser.add_argument("-P", "--password", dest="password", type=str, help="Password if server requires one")
+    parser.add_argument("-p", "--port", dest="port", type=int, help="Port for the mumble server")
+    parser.add_argument("-c", "--channel", dest="channel", type=str, help="Default chanel for the bot")
 
     args = parser.parse_args()
-    config = configparser.ConfigParser(interpolation=None)
+    config = configparser.ConfigParser(interpolation=None, allow_no_value=True)
     parsed_configs = config.read(['configuration.default.ini', args.config], encoding='latin-1')
 
     if len(parsed_configs) == 0:


### PR DESCRIPTION
Adds the command-line arguments to the configuration file and removes any default values and requirements from the command-line arguments.

Keeps compatibility with command-line arguments, command-line arguments are prioritized over configuration values.

Sets ConfigParser allow_no_value=True to allow password and channel to exist as empty values in the config file. (Will be parsed to None)