### PR TITLE
Store volume in the config file, write the config file, fixes

### DIFF
--- a/configuration.default.ini
+++ b/configuration.default.ini
@@ -39,6 +39,7 @@ kill = kill
 stop_and_getout = oust
 joinme = joinme
 queue = queue
+repeat = repeat
 
 [radio]
 ponyville = http://192.99.131.205:8000/stream.mp3

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -184,7 +184,7 @@ class MumbleBot:
                     self.volume = float(float(parameter) / 100)
                     self.send_msg_channel(var.config.get('strings', 'change_volume') % (
                         int(self.volume * 100), self.mumble.users[text.actor]['name']))
-                    var.config.set('bot', 'volume', self.volume)
+                    var.config.set('bot', 'volume', str(self.volume))
                 else:
                     self.send_msg_channel(var.config.get('strings', 'current_volume') % int(self.volume * 100))
 

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -85,11 +85,11 @@ class MumbleBot:
             password = var.config.get("server", "password")
 
         if args.user:
-            user = args.user
+            username = args.user
         else:
-            user = var.config.get("bot", "user")
+            username = var.config.get("bot", "username")
 
-        self.mumble = pymumble.Mumble(host, user=user, port=port, password=password,
+        self.mumble = pymumble.Mumble(host, user=username, port=port, password=password,
                                       debug=var.config.getboolean('debug', 'mumbleConnection'))
         self.mumble.callbacks.set_callback("text_received", self.message_received)
 

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -184,6 +184,7 @@ class MumbleBot:
                     self.volume = float(float(parameter) / 100)
                     self.send_msg_channel(var.config.get('strings', 'change_volume') % (
                         int(self.volume * 100), self.mumble.users[text.actor]['name']))
+                    var.config.set('bot', 'volume', self.volume)
                 else:
                     self.send_msg_channel(var.config.get('strings', 'current_volume') % int(self.volume * 100))
 
@@ -372,6 +373,9 @@ class MumbleBot:
             time.sleep(0.01)
         time.sleep(0.5)
 
+        if self.exit:
+            util.write_config()
+
     def stop(self):
         if self.thread:
             var.current_music = None
@@ -408,8 +412,9 @@ if __name__ == '__main__':
     parser.add_argument("-c", "--channel", dest="channel", type=str, help="Default channel for the bot")
 
     args = parser.parse_args()
+    var.configfile = args.config
     config = configparser.ConfigParser(interpolation=None, allow_no_value=True)
-    parsed_configs = config.read(['configuration.default.ini', args.config], encoding='latin-1')
+    parsed_configs = config.read(['configuration.default.ini', var.configfile], encoding='latin-1')
 
     if len(parsed_configs) == 0:
         print('Could not read configuration from file \"{}\"'.format(args.config), file=sys.stderr)

--- a/util.py
+++ b/util.py
@@ -66,6 +66,11 @@ def zipdir(zippath, zipname_prefix=None):
     return zipname
 
 
+def write_config():
+    with open(var.configfile, 'w') as f:
+        var.config.write(f)
+
+
 class Dir(object):
     def __init__(self, path):
         self.name = os.path.basename(path.strip('/'))

--- a/variables.py
+++ b/variables.py
@@ -3,4 +3,5 @@ playlist = []
 user = ""
 music_folder = ""
 is_proxified = False
+configfile = None
 config = None


### PR DESCRIPTION
Fixes commands failing because of repeat missing from the config.

Fixes bot startup without specifying --user

Implements a function to write the configuration file on exit, stores the volume to the config when it is changed.