### PR TITLE
Write metadata and use cached files without youtube-dl, fix youtube-dl processing

### DIFF
--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -325,7 +325,7 @@ class MumbleBot:
         mp3 = path.replace(".%(ext)s", ".mp3")
         if os.path.isfile(mp3):
             audio = EasyID3(mp3)
-            video_title = audio["title"]
+            video_title = audio["title"][0]
         else:
             ydl_opts = {
                 'format': 'bestaudio/best',

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -320,7 +320,7 @@ class MumbleBot:
 
     def download_music(self, url):
         url_hash = hashlib.md5(url.encode()).hexdigest()
-        path = var.config.get('bot', 'tmp_folder') + url_hash + ".mp3"
+        path = var.config.get('bot', 'tmp_folder') + url_hash + ".%(ext)s"
         ydl_opts = {
             'format': 'bestaudio/best',
             'outtmpl': path,
@@ -343,7 +343,7 @@ class MumbleBot:
                     pass
                 else:
                     break
-        return path, video_title
+        return path.replace(".%(ext)s", ".mp3"), video_title
 
     def loop(self):
         raw_music = ""

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -330,8 +330,8 @@ class MumbleBot:
             'postprocessors': [{
                 'key': 'FFmpegExtractAudio',
                 'preferredcodec': 'mp3',
-                'preferredquality': '192',
-            }]
+                'preferredquality': '192'},
+                {'key': 'FFmpegMetadata'}]
         }
         video_title = ""
         with youtube_dl.YoutubeDL(ydl_opts) as ydl:

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -20,6 +20,7 @@ import util
 import base64
 from PIL import Image
 from io import BytesIO
+from mutagen.easyid3 import EasyID3
 
 
 class MumbleBot:
@@ -321,29 +322,34 @@ class MumbleBot:
     def download_music(self, url):
         url_hash = hashlib.md5(url.encode()).hexdigest()
         path = var.config.get('bot', 'tmp_folder') + url_hash + ".%(ext)s"
-        ydl_opts = {
-            'format': 'bestaudio/best',
-            'outtmpl': path,
-            'noplaylist': True,
-            'writethumbnail': True,
-            'updatetime': False,
-            'postprocessors': [{
-                'key': 'FFmpegExtractAudio',
-                'preferredcodec': 'mp3',
-                'preferredquality': '192'},
-                {'key': 'FFmpegMetadata'}]
-        }
-        video_title = ""
-        with youtube_dl.YoutubeDL(ydl_opts) as ydl:
-            for i in range(2):
-                try:
-                    info_dict = ydl.extract_info(url)
-                    video_title = info_dict['title']
-                except youtube_dl.utils.DownloadError:
-                    pass
-                else:
-                    break
-        return path.replace(".%(ext)s", ".mp3"), video_title
+        mp3 = path.replace(".%(ext)s", ".mp3")
+        if os.path.isfile(mp3):
+            audio = EasyID3(mp3)
+            video_title = audio["title"]
+        else:
+            ydl_opts = {
+                'format': 'bestaudio/best',
+                'outtmpl': path,
+                'noplaylist': True,
+                'writethumbnail': True,
+                'updatetime': False,
+                'postprocessors': [{
+                    'key': 'FFmpegExtractAudio',
+                    'preferredcodec': 'mp3',
+                    'preferredquality': '192'},
+                    {'key': 'FFmpegMetadata'}]
+            }
+            video_title = ""
+            with youtube_dl.YoutubeDL(ydl_opts) as ydl:
+                for i in range(2):
+                    try:
+                        info_dict = ydl.extract_info(url)
+                        video_title = info_dict['title']
+                    except youtube_dl.utils.DownloadError:
+                        pass
+                    else:
+                        break
+        return mp3, video_title
 
     def loop(self):
         raw_music = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask
 youtube-dl
 python-magic
 Pillow
+mutagen


### PR DESCRIPTION
Fixes youtube-dl processing. Currently botamusique instantly sets the filename for youtube-dl to mp3 so it downloads whatever it gets (ex. WebM) and calls that an mp3, while the actual post process conversion fails.

Implements writing metadata to files using a youtube-dl postprocessor.
Checks if a file exists first before downloading it, then reads id3 tags from it and returns them without ever calling youtube-dl. This allows the tmp folder cache to work well.