### PR TITLE
Pull request for the first trivial implementation of the volume slider in the webinterface

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -234,13 +234,15 @@ def status():
                         'current_index': var.playlist.current_index,
                         'empty': False,
                         'play': not var.bot.is_pause,
-                        'mode': var.playlist.mode})
+                        'mode': var.playlist.mode,
+                        'volume': var.db.getfloat('bot', 'volume')})
     else:
         return jsonify({'ver': var.playlist.version,
                         'current_index': var.playlist.current_index,
                         'empty': True,
                         'play': not var.bot.is_pause,
-                        'mode': var.playlist.mode})
+                        'mode': var.playlist.mode,
+                        'volume': var.db.getfloat('bot', 'volume')})
 
 
 @web.route("/post", methods=['POST'])
@@ -401,6 +403,16 @@ def post():
                     var.bot.volume_set = 0
                 var.db.set('bot', 'volume', str(var.bot.volume_set))
                 log.info("web: volume up to %d" % (var.bot.volume_set * 100))
+            elif action == "volume_set_value":
+                if 'new_volume' in request.form:
+                    # new_volume is slider value ranging from 0-100
+                    var.bot.volume_set = (request.form['new_volume'] * 0.01)
+                    if var.bot.volume_set > 1:
+                        var.bot.volume_set = 1
+                    elif var.bot.volume_set < 0:
+                        var.bot.volume_set = 0
+                    var.db.set('bot', 'volume', str(var.bot.volume_set))
+                    log.info("web: volume set to %d" % (var.bot.volume_set * 100))
 
     return status()
 

--- a/interface.py
+++ b/interface.py
@@ -235,14 +235,14 @@ def status():
                         'empty': False,
                         'play': not var.bot.is_pause,
                         'mode': var.playlist.mode,
-                        'volume': var.db.getfloat('bot', 'volume')})
+                        'volume': var.bot.volume_set})
     else:
         return jsonify({'ver': var.playlist.version,
                         'current_index': var.playlist.current_index,
                         'empty': True,
                         'play': not var.bot.is_pause,
                         'mode': var.playlist.mode,
-                        'volume': var.db.getfloat('bot', 'volume')})
+                        'volume': var.bot.volume_set})
 
 
 @web.route("/post", methods=['POST'])
@@ -405,12 +405,13 @@ def post():
                 log.info("web: volume up to %d" % (var.bot.volume_set * 100))
             elif action == "volume_set_value":
                 if 'new_volume' in request.form:
-                    # new_volume is slider value ranging from 0-100
-                    var.bot.volume_set = (int(request.form['new_volume']) * 0.01)
-                    if var.bot.volume_set > 1:
+                    if float(request.form['new_volume']) > 1:
                         var.bot.volume_set = 1
-                    elif var.bot.volume_set < 0:
+                    elif float(request.form['new_volume']) < 0:
                         var.bot.volume_set = 0
+                    else:
+                        # value for new volume is between 0 and 1, round to two decimal digits
+                        var.bot.volume_set = round(float(request.form['new_volume']), 2)
                     var.db.set('bot', 'volume', str(var.bot.volume_set))
                     log.info("web: volume set to %d" % (var.bot.volume_set * 100))
 

--- a/interface.py
+++ b/interface.py
@@ -406,7 +406,7 @@ def post():
             elif action == "volume_set_value":
                 if 'new_volume' in request.form:
                     # new_volume is slider value ranging from 0-100
-                    var.bot.volume_set = (request.form['new_volume'] * 0.01)
+                    var.bot.volume_set = (int(request.form['new_volume']) * 0.01)
                     if var.bot.volume_set > 1:
                         var.bot.volume_set = 1
                     elif var.bot.volume_set < 0:

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -108,4 +108,7 @@
    font-style: italic !important;
    font-weight: 300;
 }
-
+#volume-slider {
+   margin-top: 8px;
+   margin-right: 6px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -71,7 +71,7 @@
 
                             <input type="range" class="custom-range" id="volume-slider" 
                                     min="0" max="1" step="0.01" value="0.5"
-                                    onchange="request('post', {action : 'volume_set_value', new_volume : this.value})">
+                                    onchange="setVolumeDelayed(this.value)">
                             </input>
 
                             <button type="button" class="btn btn-warning btn-space"
@@ -493,6 +493,8 @@
         var playlist_range_from = 0;
         var playlist_range_to = 0;
 
+        var last_volume = 0;
+
         function request(_url, _data, refresh=false){
             console.log(_data);
             $.ajax({
@@ -726,12 +728,15 @@
                 $("#random-btn").removeClass("btn-primary").addClass("btn-secondary").prop("disabled", false);
                 $("#autoplay-btn").removeClass("btn-secondary").addClass("btn-primary").prop("disabled", true);
             }
-            if(volume > 1) {
-                document.getElementById("volume-slider").value = 1;
-            } else if(volume < 0) {
-                document.getElementById("volume-slider").value = 0;
-            } else {
-                document.getElementById("volume-slider").value = volume;
+            if(volume != last_volume) {
+                last_volume = volume;
+                if(volume > 1) {
+                    document.getElementById("volume-slider").value = 1;
+                } else if(volume < 0) {
+                    document.getElementById("volume-slider").value = 0;
+                } else {
+                    document.getElementById("volume-slider").value = volume;
+                }
             }
         }
 
@@ -1169,6 +1174,13 @@
             updateResults(active_page);
         }
 
+        var volume_update_timer;
+        function setVolumeDelayed(new_volume_value) {
+            window.clearTimeout(volume_update_timer);
+            volume_update_timer = window.setTimeout(function() {
+                request('post', {action : 'volume_set_value', new_volume : new_volume_value});
+                }, 500); // delay in milliseconds
+        }
 
         themeInit();
         updateResults();

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,7 +70,7 @@
                             </button>
 
                             <input type="range" class="custom-range" id="volume-slider" 
-                                    min="0" max="100" step="1" value="50"
+                                    min="0" max="1" step="0.01" value="0.5"
                                     onchange="request('post', {action : 'volume_set_value', new_volume : this.value})">
                             </input>
 
@@ -726,7 +726,13 @@
                 $("#random-btn").removeClass("btn-primary").addClass("btn-secondary").prop("disabled", false);
                 $("#autoplay-btn").removeClass("btn-secondary").addClass("btn-primary").prop("disabled", true);
             }
-            document.getElementById("volume-slider").value = Math.round(volume*100);
+            if(volume > 1) {
+                document.getElementById("volume-slider").value = 1;
+            } else if(volume < 0) {
+                document.getElementById("volume-slider").value = 0;
+            } else {
+                document.getElementById("volume-slider").value = volume;
+            }
         }
 
         function themeInit(){

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,15 +68,17 @@
                                     onclick="request('post', {action : 'volume_down'})">
                                 <i class="fa fa-volume-down" aria-hidden="true"></i>
                             </button>
+
+                            <input type="range" class="custom-range" id="volume-slider" 
+                                    min="0" max="100" step="1" value="50"
+                                    onchange="request('post', {action : 'volume_set_value', new_volume : this.value})">
+                            </input>
+
                             <button type="button" class="btn btn-warning btn-space"
                                     onclick="request('post', {action : 'volume_up'})">
                                 <i class="fa fa-volume-up" aria-hidden="true"></i>
                             </button>
 
-                            <input id="volume-slider" type="range"
-                                    min="0" max="100" step="1" value="50"
-                                    onchange="request('post', {action : 'volume_set_value', new_volume : this.value})">
-                            </input>
                         </div>
 
                         <table class="table">

--- a/templates/index.html
+++ b/templates/index.html
@@ -72,6 +72,11 @@
                                     onclick="request('post', {action : 'volume_up'})">
                                 <i class="fa fa-volume-up" aria-hidden="true"></i>
                             </button>
+
+                            <input id="volume-slider" type="range"
+                                    min="0" max="100" step="1" value="50"
+                                    onchange="request('post', {action : 'volume_set_value', new_volume : this.value})">
+                            </input>
                         </div>
 
                         <table class="table">
@@ -497,7 +502,7 @@
                         if (data.ver !== playlist_ver) {
                             checkForPlaylistUpdate();
                         }
-                        updateControls(data.empty, data.play, data.mode);
+                        updateControls(data.empty, data.play, data.mode, data.volume);
                     }
                 }
             });
@@ -659,7 +664,7 @@
                                 displayActiveItem(data.current_index);
                             }
                         }
-                        updateControls(data.empty, data.play, data.mode);
+                        updateControls(data.empty, data.play, data.mode, data.volume);
                     }
                 }
             });
@@ -682,7 +687,7 @@
             );
         }
 
-        function updateControls(empty, play, mode){
+        function updateControls(empty, play, mode, volume){
             if(empty){
                 $("#play-btn").prop("disabled", true);
                 $("#pause-btn").prop("disabled", true);
@@ -719,7 +724,7 @@
                 $("#random-btn").removeClass("btn-primary").addClass("btn-secondary").prop("disabled", false);
                 $("#autoplay-btn").removeClass("btn-secondary").addClass("btn-primary").prop("disabled", true);
             }
-
+            $("#volume-slider").value = volume;
         }
 
         function themeInit(){

--- a/templates/index.html
+++ b/templates/index.html
@@ -724,7 +724,7 @@
                 $("#random-btn").removeClass("btn-primary").addClass("btn-secondary").prop("disabled", false);
                 $("#autoplay-btn").removeClass("btn-secondary").addClass("btn-primary").prop("disabled", true);
             }
-            $("#volume-slider").value = volume;
+            document.getElementById("volume-slider").value = Math.round(volume*100);
         }
 
         function themeInit(){


### PR DESCRIPTION
Added a volume slider in the webinterface and changed interface.py accordingly.

This does not have any CSS styling yet, do you have any design guidelines?

There might also be performance improvements possible by caching the current volume inside interface.py as currently as now every update a db query is run to get the current volume so it syncs for multiple users accessing the webinterface on their own machines at the same time.