### PR TITLE
For URLItems: clone title into keywords, allows searching

### DIFF
--- a/media/url.py
+++ b/media/url.py
@@ -42,11 +42,12 @@ class URLItem(BaseItem):
         if from_dict is None:
             super().__init__()
             self.url = url if url[-1] != "/" else url[:-1]
-            self.title = ''
+            self.title = ""
             self.duration = 0
             self.id = hashlib.md5(url.encode()).hexdigest()
             self.path = var.tmp_folder + self.id + ".mp3"
-            self.thumbnail = ''
+            self.thumbnail = ""
+            self.keywords = ""
         else:
             super().__init__(from_dict)
             self.url = from_dict['url']
@@ -126,6 +127,7 @@ class URLItem(BaseItem):
                     info = ydl.extract_info(self.url, download=False)
                     self.duration = info['duration'] / 60
                     self.title = info['title']
+                    self.keywords = info['title']
                     succeed = True
                     return True
                 except youtube_dl.utils.DownloadError:


### PR DESCRIPTION
This change copies the title into the keywords so youtube videos become searchable through the webinterface.
If a more elegant feature like searching by title is easily possible, that could be interesting to.
Ideally I would like to extend this later on by also adding the youtube channel name of the uploader into the keywords.