### PR TITLE
Stop database.py from putting empty strings into an items tag array

### DIFF
--- a/database.py
+++ b/database.py
@@ -486,7 +486,7 @@ class MusicDatabase:
         if len(results) > 0:
             for result in results:
                 id = result[0]
-                tags = result[1].strip(",").split(",")
+                tags = filter(None, result[1].strip(",").split(","))
                 lookup[id] = tags if tags[0] else []
 
         return lookup


### PR DESCRIPTION
Running the current master version with a database updated from version 1 to 2, I saw errors concerning the /playlist response which the webinterface queries every few seconds.

These were thrown because the tags array contained the string '' (empty string) for which a key lookup was attempted.
This was caused by items in the database where the tag value is only a comma (",") and can be fixed by adding a filter function in the query_tags function.

These can be fixed with the same filter statement in [interface.py:187](https://github.com/azlux/botamusique/blob/master/interface.py#L187), which felt dirty because it would be fixing symptoms instead of problems, so the digging began...