### PR TITLE
Add Popper.js link in HTML

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -462,6 +462,7 @@
     </div>
 
     <script src="static/js/jquery-3.4.1.min.js"></script>
+    <script src="static/js/popper.min.js"></script>
     <script src="static/js/bootstrap.min.js"></script>
     <script src="static/js/fontawesome.all.js"></script>
     <script src="static/js/custom.js"></script>


### PR DESCRIPTION
Forgot to add the link in HTML so popovers are broken. This fixes that.