### PR TITLE
Refactor: move music db into a separated file (#151)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,7 @@ configuration.ini
 music_folder/
 tmp/
 
-database.db
+*.db
 
 # Pycharm
 .idea/

--- a/command.py
+++ b/command.py
@@ -1151,9 +1151,9 @@ def cmd_drop_database(bot, user, text, command, parameter):
 
     if bot.is_admin(user):
         var.db.drop_table()
-        var.db = SettingsDatabase(var.dbfile)
+        var.db = SettingsDatabase(var.settings_db_path)
         var.music_db.drop_table()
-        var.music_db = MusicDatabase(var.dbfile)
+        var.music_db = MusicDatabase(var.settings_db_path)
         log.info("command: database dropped.")
         bot.send_msg(constants.strings('database_dropped'), text)
     else:

--- a/configuration.default.ini
+++ b/configuration.default.ini
@@ -45,7 +45,6 @@ admin = User1;User2;
 music_folder = music_folder/
 # Folder that stores the downloaded music.
 tmp_folder = /tmp/
-database_path = database.db
 pip3_path = venv/bin/pip
 auto_check_update = True
 logfile =

--- a/configuration.example.ini
+++ b/configuration.example.ini
@@ -24,14 +24,30 @@ port = 64738
 #username = botamusique
 #comment = Hi, I'm here to play radio, local music or youtube/soundcloud music. Have fun!
 
+
+# 'music_folder': Folder that stores your local songs.
+#music_folder = music_folder/
+
+# 'database_path': The path of the database. The database will store things like your volume
+#    set by command !volume, your playback mode and your playlist, banned URLs, etc.
+#    This option will be overridden by command line arguments.
+# 'music_database_path': The path of database that stores the music library. Can be disabled by
+#    setting 'save_music_library=False'
+#database_path=settings.db
+#music_database_path=music.db
+
+# 'admin': Users allowed to kill the bot, or ban URLs. Separated by ';'
+#admin = User1;User2;
+
+
 # 'volume' is default volume from 0 to 1.
 # This option will be overridden by value in the database.
 #volume = 0.1
 
 # 'playback_mode' defined the playback mode of the bot.
-# it should be one of "one-shot" (remove item once played), "repeat" (looping through the playlist),
-# or "random" (randomize the playlist), "autoplay" (randomly grab something from the music library).
-# This option will be overridden by value in the database.
+#    it should be one of "one-shot" (remove item once played), "repeat" (looping through the playlist),
+#    or "random" (randomize the playlist), "autoplay" (randomly grab something from the music library).
+#    This option will be overridden by value in the database.
 # 'autoplay_length': how many songs the autoplay mode fills the playlist
 # 'clear_when_stop_in_oneshot': clear the playlist when stop the bot in one-shot mode.
 #playback_mode = one-shot
@@ -41,17 +57,6 @@ port = 64738
 # target version, stable or testing (testing need to bot installed with git)
 # stable will use simple bash with curl command to get releases, testing will follow github master branch with git commands
 #target_version = stable
-
-# 'admin': Users allowed to kill the bot, or ban URLs. Separated by ';'
-#admin = User1;User2;
-
-# 'music_folder': Folder that stores your local songs.
-#music_folder = music_folder/
-
-# 'database_path': The path of the database. The database will store things like your volume
-# set by command !volume, your playback mode and your playlist, etc.
-# This option will be overridden by command line arguments.
-#database_path = database.db
 
 # 'tmp_folder': Folder that stores the downloaded music.
 # 'tmp_folder_max_size': in MB, 0 for no cache, -1 for unlimited size
@@ -79,11 +84,11 @@ port = 64738
 #save_music_library = True
 
 # 'refresh_cache_on_startup': If this is set true, the bot will refresh its music directory cache when starting up.
-#  But it won't reload metadata from each files. If set to False, it will used the cache last time.
+#     But it won't reload metadata from each files. If set to False, it will used the cache last time.
 #refresh_cache_on_startup = True
 
 # 'save_playlist': If save_playlist is set True, the bot will save current playlist before quitting
-# and reload it the next time it start. It requires save_music_library to be True to function.
+#    and reload it the next time it start. It requires save_music_library to be True to function.
 #save_playlist = True
 
 # 'max_track_playlist': Maximum track played when a playlist is added.
@@ -93,24 +98,24 @@ port = 64738
 #max_track_duration = 60
 
 # 'ducking': If ducking is enabled, the bot will automatically attenuate its
-#  volume when someone is talking.
+#     volume when someone is talking.
 #ducking = False
 #ducking_volume = 0.05
 #ducking_threshold = 3000
 
 # 'when_nobody_in_channel': Specify what the bot should do if nobody is in the channel.
-# Possible value of this options are:
-#  - "pause",
-#  - "pause_resume" (pause and resume once somebody re-enters the channel)
-#  - "stop" (also clears playlist)
-#  - "nothing" (do nothing)
+#    Possible value of this options are:
+#     - "pause",
+#     - "pause_resume" (pause and resume once somebody re-enters the channel)
+#     - "stop" (also clears playlist)
+#     - "nothing" (do nothing)
 #when_nobody_in_channel = nothing
 
 # [webinterface] stores settings related to the web interface.
 [webinterface]
 # 'enable': Set 'enabled' to True if you'd like to use the web interface to manage
-#  your playlist, upload files, etc.
-#  The web interface is disable by default for security and performance reason.
+#     your playlist, upload files, etc.
+#     The web interface is disable by default for security and performance reason.
 #enabled = False
 #listening_addr = 127.0.0.1
 #listening_port = 8181
@@ -148,7 +153,7 @@ port = 64738
 
 
 # You may also customize commands recognized by the bot. For a full list of commands,
-#  see configuration.default.ini. Copy options you want to edit into this file.
+#    see configuration.default.ini. Copy options you want to edit into this file.
 #play_file = file, f
 #play_file_match = filematch, fm
 

--- a/media/cache.py
+++ b/media/cache.py
@@ -115,6 +115,7 @@ class MusicCache(dict):
                 self.log.debug("library: music save into database: %s" % item.format_debug_string())
                 self.db.insert_music(item.to_dict())
 
+        self.db.manage_special_tags()
         self.dir_lock.release()
 
 

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -666,7 +666,7 @@ if __name__ == '__main__':
     parser.add_argument("--config", dest='config', type=str, default='configuration.ini',
                         help='Load configuration from this file. Default: configuration.ini')
     parser.add_argument("--db", dest='db', type=str,
-                        default=None, help='settings database file. Default: settings.db')
+                        default=None, help='settings database file. Default: settings-{username_of_the_bot}.db')
     parser.add_argument("--music-db", dest='music_db', type=str,
                         default=None, help='music library database file. Default: music.db')
 
@@ -739,8 +739,14 @@ if __name__ == '__main__':
     # ======================
     #     Load Database
     # ======================
+    if args.user:
+        username = args.user
+    else:
+        username = var.config.get("bot", "username")
+
+    sanitized_username = "".join([x if x.isalnum() else "_" for x in username])
     var.settings_db_path = args.db if args.db is not None else util.solve_filepath(
-        config.get("bot", "database_path", fallback="settings.db"))
+        config.get("bot", "database_path", fallback=f"settings-{sanitized_username}.db"))
     var.music_db_path = args.music_db if args.music_db is not None else util.solve_filepath(
         config.get("bot", "music_database_path", fallback="music.db"))
 
@@ -775,7 +781,6 @@ if __name__ == '__main__':
     # ======================
     #  Create bot instance
     # ======================
-
     var.bot = MumbleBot(args)
     command.register_all_commands(var.bot)
 

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -23,7 +23,7 @@ from packaging import version
 import util
 import command
 import constants
-from database import SettingsDatabase, MusicDatabase
+from database import SettingsDatabase, MusicDatabase, DatabaseMigration
 import media.system
 from media.item import ValidationFailedError, PreparationFailedError
 from media.playlist import BasePlaylist
@@ -666,7 +666,9 @@ if __name__ == '__main__':
     parser.add_argument("--config", dest='config', type=str, default='configuration.ini',
                         help='Load configuration from this file. Default: configuration.ini')
     parser.add_argument("--db", dest='db', type=str,
-                        default=None, help='database file. Default: database.db')
+                        default=None, help='settings database file. Default: settings.db')
+    parser.add_argument("--music-db", dest='music_db', type=str,
+                        default=None, help='music library database file. Default: music.db')
 
     parser.add_argument("-q", "--quiet", dest="quiet",
                         action="store_true", help="Only Error logs")
@@ -691,20 +693,21 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
+    # ======================
+    #     Load Config
+    # ======================
+
     config = configparser.ConfigParser(interpolation=None, allow_no_value=True)
+    var.config = config
     parsed_configs = config.read([util.solve_filepath('configuration.default.ini'), util.solve_filepath(args.config)],
                                  encoding='utf-8')
-    var.dbfile = args.db if args.db is not None else util.solve_filepath(
-        config.get("bot", "database_path", fallback="database.db"))
-
     if len(parsed_configs) == 0:
         logging.error('Could not read configuration from file \"{}\"'.format(args.config))
         sys.exit()
 
-    var.config = config
-    var.db = SettingsDatabase(var.dbfile)
-
-    # Setup logger
+    # ======================
+    #     Setup Logger
+    # ======================
 
     bot_logger = logging.getLogger("bot")
     formatter = logging.Formatter('[%(asctime)s %(levelname)s %(threadName)s] %(message)s', "%b %d %H:%M:%S")
@@ -732,14 +735,32 @@ if __name__ == '__main__':
     logging.getLogger("root").addHandler(handler)
     var.bot_logger = bot_logger
 
+
+    # ======================
+    #     Load Database
+    # ======================
+    var.settings_db_path = args.db if args.db is not None else util.solve_filepath(
+        config.get("bot", "database_path", fallback="settings.db"))
+    var.music_db_path = args.music_db if args.music_db is not None else util.solve_filepath(
+        config.get("bot", "music_database_path", fallback="music.db"))
+
+    var.db = SettingsDatabase(var.settings_db_path)
+
     if var.config.get("bot", "save_music_library", fallback=True):
-        var.music_db = MusicDatabase(var.dbfile)
+        var.music_db = MusicDatabase(var.music_db_path)
     else:
         var.music_db = MusicDatabase(":memory:")
 
+    DatabaseMigration(var.db, var.music_db).migrate()
+
     var.cache = MusicCache(var.music_db)
 
-    # load playback mode
+    if var.config.get("bot", "refresh_cache_on_startup", fallback=True):
+        var.cache.build_dir_cache()
+
+    # ======================
+    #   Load playback mode
+    # ======================
     playback_mode = None
     if var.db.has_option("playlist", "playback_mode"):
         playback_mode = var.db.get('playlist', 'playback_mode')
@@ -751,11 +772,12 @@ if __name__ == '__main__':
     else:
         raise KeyError("Unknown playback mode '%s'" % playback_mode)
 
+    # ======================
+    #  Create bot instance
+    # ======================
+
     var.bot = MumbleBot(args)
     command.register_all_commands(var.bot)
-
-    if var.config.get("bot", "refresh_cache_on_startup", fallback=True):
-        var.cache.build_dir_cache()
 
     # load playlist
     if var.config.getboolean('bot', 'save_playlist', fallback=True):

--- a/variables.py
+++ b/variables.py
@@ -13,7 +13,8 @@ cache: 'media.cache.MusicCache' = None
 user = ""
 is_proxified = False
 
-dbfile = None
+settings_db_path = None
+music_db_path = None
 db = None
 music_db: 'database.MusicDatabase' = None
 config: 'database.SettingsDatabase' = None


### PR DESCRIPTION
As mentioned in #151.

IMPORTANT NOTE:
The default database path has changed. It was database.db, but
now they ARE settings.db and music.db.

Database migration will detect music table in settings.db, and
move it out of settings.db.

To update from old version, you need to
 1. if you use your own db path settings in the command
    line or in configuration.ini, you don't have to change
    anything;
 1. or, if you use default database path, rename database.db
    into settings.db.

I'd like to invite @felix91gr to test this change.