### PR TITLE
Skip unnecessary MP3 conversion via FFmpeg after audio download

### DIFF
--- a/media/url.py
+++ b/media/url.py
@@ -45,7 +45,7 @@ class URLItem(BaseItem):
             self.title = ""
             self.duration = 0
             self.id = hashlib.md5(url.encode()).hexdigest()
-            self.path = var.tmp_folder + self.id + ".mp3"
+            self.path = var.tmp_folder + self.id
             self.thumbnail = ""
             self.keywords = ""
         else:
@@ -145,8 +145,7 @@ class URLItem(BaseItem):
 
         self.downloading = True
         base_path = var.tmp_folder + self.id
-        save_path = base_path + ".%(ext)s"
-        mp3_path = base_path + ".mp3"
+        save_path = base_path
 
         # Download only if music is not existed
         self.ready = "preparing"
@@ -154,15 +153,10 @@ class URLItem(BaseItem):
         self.log.info("bot: downloading url (%s) %s " % (self.title, self.url))
         ydl_opts = {
             'format': 'bestaudio/best',
-            'outtmpl': save_path,
+            'outtmpl': base_path,
             'noplaylist': True,
             'writethumbnail': True,
-            'updatetime': False,
-            'postprocessors': [{
-                'key': 'FFmpegExtractAudio',
-                'preferredcodec': 'mp3',
-                'preferredquality': '192'},
-                {'key': 'FFmpegMetadata'}]
+            'updatetime': False
         }
 
         with youtube_dl.YoutubeDL(ydl_opts) as ydl:
@@ -180,7 +174,7 @@ class URLItem(BaseItem):
                     self.log.error("bot: download failed with error:\n %s" % error)
 
             if download_succeed:
-                self.path = mp3_path
+                self.path = save_path
                 self.ready = "yes"
                 self.log.info(
                     "bot: finished downloading url (%s) %s, saved to %s." % (self.title, self.url, self.path))


### PR DESCRIPTION
Currently, after downloading YouTube videos, FFmpeg is used to convert the downloaded audio file into MP3 for historic reasons (there was no database to keep the metadata around, so the ID3 tags in the MP3 file were necessary to be able to read the metadata later on).

Now that a metadata database exists, this is no longer necessary. This conversion is also fairly straining for slower CPUs or CPUs that do not offer the appropriate processor extensions to be able to accelerate this conversion, such as older ARM devices - in my case an ARMv7 32-bit device, where the conversion could take over a minute for a fairly simple 3-minute audio file of keeping a single core maxed out.

This should also result in less latency playing audio files on stronger processors, though probably less noticeably.

Fixes #205. See also this ticket for the discussion preceding this.