### PR TITLE
Added multi-stage docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,51 @@
-FROM python:slim
-ENV DEBIAN_FRONTEND noninteractive
+ARG ARCH=
 
-EXPOSE 8181
-
-RUN apt update && \
-    apt install -y opus-tools ffmpeg libmagic-dev curl tar && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY . /botamusique
-
+FROM ${ARCH}python:3-slim-buster AS source
+ARG VERSION=7.1
+ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /botamusique
+RUN apt-get update && apt-get install -y git 
+RUN git clone --recurse-submodules https://github.com/azlux/botamusique.git . && git checkout $VERSION
 
-RUN rm -rf .git*
 
-RUN python3 -m venv venv && \
-    venv/bin/pip install wheel && \
-    venv/bin/pip install -r requirements.txt
+FROM ${ARCH}python:3-slim-buster AS python-builder
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /botamusique
+RUN apt-get update \
+    && apt-get install -y gcc ffmpeg libjpeg-dev libmagic-dev opus-tools zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=source /botamusique .
+RUN python3 -m venv venv \
+    && venv/bin/pip install wheel \
+    && venv/bin/pip install -r requirements.txt
 
+
+FROM ${ARCH}node:14-buster-slim AS node-builder
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /botamusique/web
+COPY --from=source /botamusique/web .
+RUN npm install
+RUN npm run build
+
+
+FROM ${ARCH}python:3-slim-buster AS template-builder
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /botamusique
+COPY --from=python-builder /botamusique .
+COPY --from=node-builder /botamusique/templates templates
+RUN venv/bin/python scripts/translate_templates.py --lang-dir /botamusique/lang --template-dir /botamusique/templates
+
+
+FROM ${ARCH}python:3-slim-buster
+ENV DEBIAN_FRONTEND=noninteractive
+EXPOSE 8181
+WORKDIR /botamusique
+RUN apt-get update \
+    && apt-get install -y ffmpeg libmagic-dev opus-tools zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=python-builder /botamusique .
+COPY --from=node-builder /botamusique/static static
+COPY --from=template-builder /botamusique/templates templates
 RUN chmod +x entrypoint.sh
-
 ENTRYPOINT [ "/botamusique/entrypoint.sh" ]
-CMD ["venv/bin/python", "mumbleBot.py"]
+CMD ["/botamusique/venv/bin/python", "/botamusique/mumbleBot.py"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,23 @@
+FROM python:slim
+ENV DEBIAN_FRONTEND noninteractive
+
+EXPOSE 8181
+
+RUN apt update && \
+    apt install -y opus-tools ffmpeg libmagic-dev curl tar && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . /botamusique
+
+WORKDIR /botamusique
+
+RUN rm -rf .git*
+
+RUN python3 -m venv venv && \
+    venv/bin/pip install wheel && \
+    venv/bin/pip install -r requirements.txt
+
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT [ "/botamusique/entrypoint.sh" ]
+CMD ["venv/bin/python", "mumbleBot.py"]


### PR DESCRIPTION
The following is the Dockerfile I use to build standalone botamusique containers when new versions are tagged. I figured I would propose using this version as the current one requires setup to be run in the currently pulled repository and cannot be used as part of a build pipeline.

The build-arg VERSION can be used to point at tags, branches, or commits.