### PR TITLE
Add "requirements.txt" for pip as separate docker layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,16 @@ RUN apt update && \
     apt install -y opus-tools ffmpeg libmagic-dev curl tar && \
     rm -rf /var/lib/apt/lists/*
 
-COPY . /botamusique
-
+RUN mkdir /botamusique
+COPY requirements.txt /botamusique
 WORKDIR /botamusique
-
 RUN rm -rf .git*
 
 RUN python3 -m venv venv && \
     venv/bin/pip install wheel && \
     venv/bin/pip install -r requirements.txt
 
+COPY . /botamusique
 RUN chmod +x entrypoint.sh
 
 ENTRYPOINT [ "/botamusique/entrypoint.sh" ]


### PR DESCRIPTION
Hi,

Best practice in docker AFAIK is to reduce the number of layers by as much as possible. Therefore, this PR is mostly a suggestion 😄 

By adding the `requirements.txt` as a separate layer and then doing a `pip install` means you don't have to re-build python dependencies for every change in the murmur project. I.e. less (re)build time. Since you get a static build cache, I think this is acceptable wrt docker best practices.