### PR TITLE
Add npm to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 EXPOSE 8181
 
 RUN apt update && \
-    apt install -y opus-tools ffmpeg libmagic-dev curl tar && \
+    apt install -y opus-tools ffmpeg libmagic-dev curl tar npm && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /botamusique
@@ -17,6 +17,7 @@ RUN python3 -m venv venv && \
     venv/bin/pip install wheel && \
     venv/bin/pip install -r requirements.txt
 
+RUN (cd web/ && npm install && npm run build)
 RUN chmod +x entrypoint.sh
 
 ENTRYPOINT [ "/botamusique/entrypoint.sh" ]


### PR DESCRIPTION
In section of https://github.com/azlux/botamusique#installation,
"Build from source code", there are now steps involving `npm` builds.

Without this step, frontend does not build in dockerfile