### PR TITLE
Import local libs as extensions

### DIFF
--- a/command.py
+++ b/command.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+
 import logging
 import secrets
 import datetime
@@ -73,6 +74,7 @@ def register_all_commands(bot):
     bot.register_command(commands('remove_webinterface_user'), cmd_web_user_remove, admin=True)
     bot.register_command(commands('list_webinterface_user'), cmd_web_user_list, admin=True)
     bot.register_command(commands('change_user_password'), cmd_user_password, no_partial_match=True)
+    
     # Just for debug use
     bot.register_command('rtrms', cmd_real_time_rms, True)
     # bot.register_command('loop', cmd_loop_state, True)
@@ -549,6 +551,7 @@ def cmd_yt_play(bot, user, text, command, parameter):
 
 def cmd_help(bot, user, text, command, parameter):
     global log
+    #for loop mudule help strig append
     bot.send_msg(tr('help'), text)
     if bot.is_admin(user):
         bot.send_msg(tr('admin_help'), text)
@@ -831,6 +834,7 @@ def cmd_mode(bot, user, text, command, parameter):
                                   user=bot.mumble.users[text.actor]['name']), text)
         if parameter == "random":
             bot.interrupt()
+            bot.launch_music()
 
 
 def cmd_play_tags(bot, user, text, command, parameter):
@@ -1248,3 +1252,5 @@ def cmd_loop_state(bot, user, text, command, parameter):
 
 def cmd_item(bot, user, text, command, parameter):
     var.playlist._debug_print()
+
+

--- a/configuration.default.ini
+++ b/configuration.default.ini
@@ -38,7 +38,7 @@ autoplay_length = 5
 clear_when_stop_in_oneshot = False
 
 # target version, stable/testing/git (git need to bot installed with git)
-target_version = git
+target_version = stable
 
 # Users allowed to kill the bot, or ban URLs.
 admin = User1;User2;
@@ -135,7 +135,8 @@ jazz = http://jazz-wr04.ice.infomaniak.ch/jazz-wr04-128.mp3 "Jazz Yeah !"
 command_symbol = !:！
 # This option split username, in case you use such kind of mumo plugins https://wiki.mumble.info/wiki/Mumo#Set_Status
 split_username_at_space = False
-
+lib-path = local-lib
+enabled_modules = []
 
 play_file = file, f
 play_file_match = filematch, fm

--- a/configuration.example.ini
+++ b/configuration.example.ini
@@ -175,7 +175,8 @@ port = 64738
 #command_symbol = !:！
 # 'split_username_at_space': This option split username, in case you use such kind of mumo plugins https://wiki.mumble.info/wiki/Mumo#Set_Status
 #split_username_at_space = False
-
+#lib-path = local-lib
+#enabled_modules = ["rsslib"]
 
 # You may also customize commands recognized by the bot. For a full list of commands,
 #    see configuration.default.ini. Copy options you want to edit into this file.

--- a/constants.py
+++ b/constants.py
@@ -1,17 +1,47 @@
 import json
+import os
 
 import variables as var
 
 default_lang_dict = {}
 lang_dict = {}
-
+default_lib_lang_dicts = {}
+lib_lang_dicts = {}
 
 def load_lang(lang):
-    global lang_dict, default_lang_dict
+    global lang_dict, default_lang_dict, lib_lang_dicts, default_lib_lang_dicts
     with open("lang/en_US.json", "r") as f:
         default_lang_dict = json.load(f)
     with open(f"lang/{lang}.json", "r") as f:
         lang_dict = json.load(f)
+
+    # Extend with the help strings from the libs.
+    folder_path = var.config.get('commands', 'lib-path')
+    flibs_enabled = json.loads(var.config.get('commands', 'enabled_modules'))
+
+    for flib in os.listdir(folder_path):
+        if flib in flibs_enabled:
+            try:
+                with open("lang/en_US.json", "r") as f:
+                    default_lib_lang_dicts[flib] = json.load(f)
+                with open(f"local-lib/{flib}/lang/{lang}.json", "r") as f:
+                    lib_lang_dicts[flib] = json.load(f)
+                    # Extend lang_dict help line
+                    helpstring_extend = lib_lang_dicts[flib]['cli'][flib]['help']
+                    lang_dict['cli']['help'] = lang_dict['cli']['help'] + helpstring_extend
+            except FileNotFoundError:
+                raise FileNotFoundError(f'Local lang error importing language file: local-lib/{flib}/lang/{lang}.json.')
+
+
+def tr_lib(option, libname, *argv, **kwargs):
+    try:
+        if option in lib_lang_dicts[libname]['lib'] and lib_lang_dicts[libname]['lib'][option]:
+            string = lib_lang_dicts[libname]['lib'][option]
+        else:
+            string = default_lib_lang_dicts[libname]['lib'][option]
+    except KeyError:
+        raise KeyError(f"Missed strings in {libname} language file: '{option}'.")
+    return _tr(string, *argv, **kwargs)
 
 
 def tr_cli(option, *argv, **kwargs):
@@ -21,7 +51,7 @@ def tr_cli(option, *argv, **kwargs):
         else:
             string = default_lang_dict['cli'][option]
     except KeyError:
-        raise KeyError("Missed strings in language file: '{string}'. ".format(string=option))
+        raise KeyError(f"Missed strings in language file: '{option}'.")
     return _tr(string, *argv, **kwargs)
 
 
@@ -32,7 +62,7 @@ def tr_web(option, *argv, **kwargs):
         else:
             string = default_lang_dict['web'][option]
     except KeyError:
-        raise KeyError("Missed strings in language file: '{string}'. ".format(string=option))
+        raise KeyError(f"Missed strings in language file: '{option}'.")
     return _tr(string, *argv, **kwargs)
 
 

--- a/interface.py
+++ b/interface.py
@@ -562,7 +562,6 @@ def library_info():
     return jsonify(dict(
         dirs=get_all_dirs(),
         upload_enabled=var.config.getboolean("webinterface", "upload_enabled", fallback=True),
-        delete_allowed=var.config.getboolean("webinterface", "delete_allowed", fallback=True),
         tags=tags,
         max_upload_file_size=max_upload_file_size
     ))
@@ -606,25 +605,22 @@ def library():
 
                 return redirect("./", code=302)
             elif request.form['action'] == 'delete':
-                if var.config.getboolean("webinterface", "delete_allowed", fallback=True):
-                    items = dicts_to_items(var.music_db.query_music(condition))
-                    for item in items:
-                        var.playlist.remove_by_id(item.id)
-                        item = var.cache.get_item_by_id(item.id)
+                items = dicts_to_items(var.music_db.query_music(condition))
+                for item in items:
+                    var.playlist.remove_by_id(item.id)
+                    item = var.cache.get_item_by_id(item.id)
 
-                        if os.path.isfile(item.uri()):
-                            log.info("web: delete file " + item.uri())
-                            os.remove(item.uri())
+                    if os.path.isfile(item.uri()):
+                        log.info("web: delete file " + item.uri())
+                        os.remove(item.uri())
 
-                        var.cache.free_and_delete(item.id)
+                    var.cache.free_and_delete(item.id)
 
-                    if len(os.listdir(var.music_folder + request.form['dir'])) == 0:
-                        os.rmdir(var.music_folder + request.form['dir'])
+                if len(os.listdir(var.music_folder + request.form['dir'])) == 0:
+                    os.rmdir(var.music_folder + request.form['dir'])
 
-                    time.sleep(0.1)
-                    return redirect("./", code=302)
-                else:
-                    abort(403)
+                time.sleep(0.1)
+                return redirect("./", code=302)
             else:
                 page_count = math.ceil(total_count / ITEM_PER_PAGE)
 

--- a/libimport.py
+++ b/libimport.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import pymumble_py3 as pymumble
 import os
 import sys
 import importlib
 import json
-from enum import Enum
 
 #import interface
-import media.system
 #import util
 import variables as var
 
@@ -52,19 +49,20 @@ def load_lib(bot, libname):
         # Execute the module in its own namespace when a module is imported or reloaded.
         log.debug(f'load_lib: try loading {lib}')
         spec.loader.exec_module(lib)
-    except Exception:
+    except Exception as e:
         del sys.modules[lm]
+        log.debug(f'{e}')
         raise ExtensionFailed()
 
-    # load lib
+    # load plugin
     try:
-        load_mod = getattr(lib, 'load_mod')
-        load_mod(bot)
+        load_plugin = getattr(lib, 'load_plugin')
+        load_plugin(bot)
     except AttributeError:
         del sys.modules[lm]
         raise NoEntryPointError()
     else:
-        log.debug(f'load_lib: self.__extensions[{load_mod}]')
+        log.debug(f'load_lib: self.__extensions[{load_plugin}]')
 
 
 def import_all_local_libs(bot):
@@ -87,5 +85,4 @@ def import_all_local_libs(bot):
         else:
             log.info(f'lib import: skipping source: {flib} (disabled or not installed)')
             log.info(f'lib import: to Install local lib use pip:\tvenv/bin/python -m pip install -e local-lib/mylib')
-
 

--- a/libimport.py
+++ b/libimport.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import pymumble_py3 as pymumble
+import os
+import sys
+import importlib
+import json
+from enum import Enum
+
+#import interface
+import media.system
+#import util
+import variables as var
+
+
+log = logging.getLogger("bot")
+
+class ExtensionFailed(LookupError):
+    pass
+
+class NoEntryPointError(LookupError):
+    pass
+
+class ExtensionNotFound(LookupError):
+    pass
+
+
+def load_lib(bot, libname):
+    # The extension name to load. It must be dot separated like
+    # regular Python imports if accessing a sub-module. e.g.
+    # foo.typical if you want to import ``foo/typical.py``.
+    # https://docs.python.org/3.8/library/importlib.html
+
+    log.info(f'lib import: setting up local lib: {libname}')
+    try:
+        # Find the spec for a module, optionally relative to the specified package name
+        spec = importlib.util.find_spec(f'{libname}.typ_{libname}')
+        log.debug(f'load_lib: activate: {libname}, spec : {spec}')
+
+        if spec is None:
+            raise ExtensionNotFound()
+        lm = 'loadmod'
+        # Create a new module based on spec.
+        lib = importlib.util.module_from_spec(spec)
+        sys.modules[lm] = lib
+    except Exception as e:
+        log.debug(f'load_lib: failed to import lib file{spec}\n{e}')
+
+    # load file
+    try:
+        # Execute the module in its own namespace when a module is imported or reloaded.
+        log.debug(f'load_lib: try loading {lib}')
+        spec.loader.exec_module(lib)
+    except Exception:
+        del sys.modules[lm]
+        raise ExtensionFailed()
+
+    # load lib
+    try:
+        load_mod = getattr(lib, 'load_mod')
+        load_mod(bot)
+    except AttributeError:
+        del sys.modules[lm]
+        raise NoEntryPointError()
+    else:
+        log.debug(f'load_lib: self.__extensions[{load_mod}]')
+
+
+def import_all_local_libs(bot):
+    # Gather libs from lib-path folder
+    folder_path = var.config.get('commands', 'lib-path')
+    flibs_enabled = json.loads(var.config.get('commands', 'enabled_modules'))
+    log.info(f'lib import: enabled local-libs: {flibs_enabled}')
+    for flib in flibs_enabled:
+        if not flib in os.listdir(folder_path):
+            log.info(f'lib import: "{flib}" is enabled in config, but does not exist in local-lib directory')
+
+    for flib in os.listdir(folder_path):
+        if flib in flibs_enabled:
+            log.debug(f'import_all_local_libs: found source: {flib}')
+            try:
+                load_lib(bot, libname=flib)
+            except Exception as e:
+                log.info(f'lib import: error importing {flib}')
+                log.debug(f'{e}')
+        else:
+            log.info(f'lib import: skipping source: {flib} (disabled or not installed)')
+            log.info(f'lib import: to Install local lib use pip:\tvenv/bin/python -m pip install -e local-lib/mylib')
+
+

--- a/local-lib/rsslib/lang/de_DE.json
+++ b/local-lib/rsslib/lang/de_DE.json
@@ -1,0 +1,11 @@
+{
+    "cli": {
+        "rsslib": {
+            "help": "<b>RSS feed</b>\n<ul>\n<li> <b>!getrss</b> - neueste RSS-Nachricht erhalten.</li>\n<li> <b>!subrss</b> - RSS-Feed abonnieren. <small> *für server registrierte nutzer</small></li>\n<li> <b>!unsubrss</b> - RSS-Feed abbestellen.<small> *für server registrierte nutzer</small></li>\n<li> <b>!setrss</b> {url} - RSS url einstellen.</li>\n<li> <b>!startrss</b> - Überwachung des RSS-Feeds starten.</li>\n</ul>"
+        }
+    },
+    "lib": {
+        "no_result": "Kein ergebnis...",
+        "read_more": "<b>Weiterlesen</b>"
+    }
+}

--- a/local-lib/rsslib/lang/en_US.json
+++ b/local-lib/rsslib/lang/en_US.json
@@ -1,0 +1,11 @@
+{
+    "cli": {
+        "rsslib": {
+            "help": "<b>RSS feed</b>\n<ul>\n<li> <b>!getrss</b> - get latest RSS message.</li>\n<li> <b>!subrss</b> - subscribe to the RSS feed.<small> *for server registered users</small></li>\n<li> <b>!unsubrss</b> - unsubscribe from the RSS feed.<small> *for server registered users</small></li>\n<li> <b>!setrss</b> {url}  - set RSS url.</li>\n<li> <b>!stoprss</b> - stop monitoring of the RSS feed.</li>\n<li> <b>!startrss</b> - start monitoring of the RSS feed.</li>\n</ul>"
+        }
+    },
+    "lib": {
+        "no_result": "no result...",
+        "read_more": "<b>Read more at<b>"
+    }
+}

--- a/local-lib/rsslib/lang/es_ES.json
+++ b/local-lib/rsslib/lang/es_ES.json
@@ -1,0 +1,11 @@
+{
+    "cli": {
+        "rsslib": {
+            "help": "<b>RSS feed</b>\n<ul>\n<li> <b>!getrss</b> - get latest RSS message.</li>\n<li> <b>!subrss</b> - subscribe to the RSS feed.<small> *for server registered users</small></li>\n<li> <b>!unsubrss</b> - unsubscribe from the RSS feed.<small> *for server registered users</small></li>\n<li> <b>!setrss</b> {url}  - set RSS url.</li>\n<li> <b>!stoprss</b> - stop monitoring of the RSS feed.</li>\n<li> <b>!startrss</b> - start monitoring of the RSS feed.</li>\n</ul>"
+        }
+    },
+    "lib": {
+        "no_result": "no result...",
+        "read_more": "<b>Read more at<b>"
+    }
+}

--- a/local-lib/rsslib/lang/fr_FR.json
+++ b/local-lib/rsslib/lang/fr_FR.json
@@ -1,0 +1,11 @@
+{
+    "cli": {
+        "rsslib": {
+            "help": "<b>RSS feed</b>\n<ul>\n<li> <b>!getrss</b> - get latest RSS message.</li>\n<li> <b>!subrss</b> - subscribe to the RSS feed.<small> *for server registered users</small></li>\n<li> <b>!unsubrss</b> - unsubscribe from the RSS feed.<small> *for server registered users</small></li>\n<li> <b>!setrss</b> {url}  - set RSS url.</li>\n<li> <b>!stoprss</b> - stop monitoring of the RSS feed.</li>\n<li> <b>!startrss</b> - start monitoring of the RSS feed.</li>\n</ul>"
+        }
+    },
+    "lib": {
+        "no_result": "no result...",
+        "read_more": "<b>Read more at<b>"
+    }
+}

--- a/local-lib/rsslib/lang/ja_JP.json
+++ b/local-lib/rsslib/lang/ja_JP.json
@@ -1,0 +1,11 @@
+{
+    "cli": {
+        "rsslib": {
+            "help": "<b>RSS feed</b>\n<ul>\n<li> <b>!getrss</b> - get latest RSS message.</li>\n<li> <b>!subrss</b> - subscribe to the RSS feed.<small> *for server registered users</small></li>\n<li> <b>!unsubrss</b> - unsubscribe from the RSS feed.<small> *for server registered users</small></li>\n<li> <b>!setrss</b> {url}  - set RSS url.</li>\n<li> <b>!stoprss</b> - stop monitoring of the RSS feed.</li>\n<li> <b>!startrss</b> - start monitoring of the RSS feed.</li>\n</ul>"
+        }
+    },
+    "lib": {
+        "no_result": "no result...",
+        "read_more": "<b>Read more at<b>"
+    }
+}

--- a/local-lib/rsslib/lang/zh_CN.json
+++ b/local-lib/rsslib/lang/zh_CN.json
@@ -1,0 +1,11 @@
+{
+    "cli": {
+        "rsslib": {
+            "help": "<b>RSS feed</b>\n<ul>\n<li> <b>!getrss</b> - get latest RSS message.</li>\n<li> <b>!subrss</b> - subscribe to the RSS feed.<small> *for server registered users</small></li>\n<li> <b>!unsubrss</b> - unsubscribe from the RSS feed.<small> *for server registered users</small></li>\n<li> <b>!setrss</b> {url}  - set RSS url.</li>\n<li> <b>!stoprss</b> - stop monitoring of the RSS feed.</li>\n<li> <b>!startrss</b> - start monitoring of the RSS feed.</li>\n</ul>"
+        }
+    },
+    "lib": {
+        "no_result": "no result...",
+        "read_more": "<b>Read more at<b>"
+    }
+}

--- a/local-lib/rsslib/libconfiguration.default.ini
+++ b/local-lib/rsslib/libconfiguration.default.ini
@@ -1,0 +1,12 @@
+[config]
+autostart = True
+rss_channel = rss
+rss_channel_id = 
+
+[feeds]
+rssfeed = https://github.com/azlux/botamusique/commits/master.atom
+previous_entry = 
+interval_mins = 10
+
+[subscriptions]
+subbed_users = []

--- a/local-lib/rsslib/libconfiguration.ini
+++ b/local-lib/rsslib/libconfiguration.ini
@@ -1,0 +1,13 @@
+[config]
+autostart = True
+rss_channel = rss
+rss_channel_id = 
+
+[feeds]
+rssfeed = https://github.com/azlux/botamusique/commits/master.atom
+previous_entry = 
+interval_mins = 10
+
+[subscriptions]
+subbed_users = []
+

--- a/local-lib/rsslib/requirements.txt
+++ b/local-lib/rsslib/requirements.txt
@@ -1,0 +1,1 @@
+feedparser

--- a/local-lib/rsslib/rsslib/typ_rsslib.py
+++ b/local-lib/rsslib/rsslib/typ_rsslib.py
@@ -1,0 +1,302 @@
+# -*- coding: utf-8 -*-
+
+import configparser
+import feedparser
+from urllib.parse import urlparse
+import json
+import time
+import hashlib
+
+import util
+from constants import tr_lib as trl, tr_cli as tr
+#import variables as var
+
+
+# TODO:
+# commands(**kargs) since __init__ self.bot
+
+
+# Index module
+route_map = {}
+def command(trig, no_partial_match=True, admin=True, methods=['handle']):
+    def inner_decorator(f):
+        if trig not in route_map:
+            route_map[trig] = {}
+            route_map[trig]['no_partial_match'] = no_partial_match
+            route_map[trig]['admin'] = admin
+            for method in methods:
+                route_map[trig][method] = f
+        return f
+    return inner_decorator
+
+
+class RSSLib():
+    def __init__(self, bot):
+        self.bot = bot
+        self.load_config()
+        self.result = trl('no_result', 'rsslib')
+
+    @command('getrss', no_partial_match=False, admin=False)
+    def cmd_showrss(self, bot, user, text, command, parameter):
+        self.get_feeds()
+        self.send_feed(text.actor)
+
+    @command('subrss', no_partial_match=False, admin=False)
+    def cmd_subrss(self, bot, user, text, command, parameter):
+        try:
+            user_id = self.bot.mumble.users[text.actor]['user_id']
+        except KeyError:
+            self.bot.mumble.users[text.actor].send_text_message(f"I'm sorry, you need to be server registerd for this feature")
+            return
+        if not user_id in self.subbed_users:
+            text_actor = self.resolve_registered_user(user_id)
+            if text_actor:
+                self.subbed_users.append(user_id)
+                self.config.set('subscriptions','subbed_users', str(self.subbed_users))
+                self.save_config()
+                self.bot.mumble.users[text_actor].send_text_message(f'You are now subscribed to the RSS feed')
+            else:
+                self.bot.log.debug(f'cmd_subrss: error text_actor: "{text_actor}", user_id: {user_id}')
+        else:
+            self.bot.mumble.users[text.actor].send_text_message(f'You already subscribed to the RSS feed')
+
+    @command('unsubrss', no_partial_match=False, admin=False)
+    def cmd_unsubrss(self, bot, user, text, command, parameter):
+        try:
+            user_id = self.bot.mumble.users[text.actor]['user_id']
+        except KeyError:
+            self.bot.mumble.users[text.actor].send_text_message(f"I'm sorry, you need to be server registerd for this feature")
+            return
+
+        if user_id in self.subbed_users:
+            self.subbed_users.remove(user_id)
+            self.config.set('subscriptions','subbed_users', str(self.subbed_users))
+            self.save_config()
+            if not user_id in self.subbed_users:
+                self.bot.mumble.users[text.actor].send_text_message(f'You unsubscribed from the RSS feed')
+            else:
+               self.bot.mumble.users[text.actor].send_text_message(f'Sorry, you are still subscribed to the RSS feed (Error).\n your id:{user_id}')
+        else:
+            self.bot.mumble.users[text.actor].send_text_message(f'You already unsubscribed from the RSS feed')
+
+    @command('setrss')
+    def cmd_urlrss(self, bot, user, text, command, parameter):
+        if not parameter:
+            self.bot.mumble.users[text.actor].send_text_message(tr('bad_parameter', command=command))
+            return
+        url = util.get_url_from_input(parameter.strip())
+        if url:
+            self.rss_url = url
+            self.config.set('feeds','rssfeed', self.rss_url)
+            self.save_config()
+            self.bot.mumble.users[text.actor].send_text_message(f'The url of the RSS feed is now set to: <i>{self.rss_url}</i>')
+        else:
+            self.bot.mumble.users[text.actor].send_text_message(tr('bad_parameter', command=command))
+
+    @command('stoprss')
+    def cmd_stoprss(self, bot, user, text, command, parameter):
+        if self.checkrss:
+            self.checkrss = False
+            self.bot.mumble.users[text.actor].send_text_message(f'RSS feed monitoring is now: {self.booleantext(self.checkrss)}')
+        else:
+            self.bot.mumble.users[text.actor].send_text_message(f'RSS feed monitoring is already: {self.booleantext(self.checkrss)}')
+
+    @command('startrss')
+    def cmd_startrss(self, bot, user, text, command, parameter):
+        if not self.checkrss:
+            self.checkrss = True
+            self.bot.mumble.users[text.actor].send_text_message(f'RSS feed monitoring is now: {self.booleantext(self.checkrss)}')
+        else:
+            self.bot.mumble.users[text.actor].send_text_message(f'RSS feed monitoring is already: {self.booleantext(self.checkrss)}')
+
+    def booleantext(self, value):
+        if value:
+            return 'On'
+        else:
+            return 'Off'
+
+    def resolve_registered_user(self, user_id):
+        for user in self.bot.mumble.users:
+            if self.bot.mumble.users[user]['session'] == self.bot.mumble.users.myself['session']:
+                continue
+            try:
+                if self.bot.mumble.users[user]['user_id'] == user_id:
+                    return self.bot.mumble.users[user]['session']
+            except KeyError: # Unregisterd
+                continue
+        return False
+
+    def send_feed(self, text_actor=None):
+        # Send to rss channel and subsribed users or specified user
+        rss_channel = self.bot.mumble.channels[self.rss_channel_id]       
+        if text_actor == None:
+            # To subbed users
+            for user_id in self.subbed_users:
+                text_actor = self.resolve_registered_user(user_id)
+                if text_actor:
+                    # Skip if user in my channel
+                    if self.bot.mumble.users[text_actor]['channel_id'] == self.rss_channel_id:
+                        pass
+                    else:
+                        self.bot.mumble.users[text_actor].send_text_message(self.result)
+                else:
+                    self.bot.log.debug(f'send_feed: error text_actor: "{text_actor}"')
+            # To channel
+            rss_channel.send_text_message(self.result)
+        else:
+            # To specific user
+            self.bot.mumble.users[text_actor].send_text_message(self.result)
+   
+    def get_feeds(self):
+        NewsFeed = feedparser.parse(self.rss_url)
+        self.bot.log.debug(f'get_feeds: Number of RSS entries : {len(NewsFeed.entries)}')
+        if len(NewsFeed.entries) > 0:
+            title = NewsFeed.entries[1]['title']
+            summary = NewsFeed.entries[1]['summary']
+            link = NewsFeed.entries[1]['link']
+            domain = urlparse(self.rss_url).netloc
+            rm = trl('read_more', 'rsslib' )
+            self.result = f'<br><b>{title}</b><br><br>{summary}<br><br>{rm} <a href="{link}">{domain}</a>'
+
+            sha1_title = hashlib.sha1(title.encode('utf-8')).hexdigest()
+            if sha1_title == self.previous_entry:
+                self.bot.log.debug(f'get_feeds: RSS nothing new')
+                return False
+            else:
+                self.bot.log.debug(f'get_feeds: RSS entry : {self.result}')
+                self.previous_entry = sha1_title
+                self.config.set('feeds','previous_entry', self.previous_entry)
+                self.save_config()
+                return True
+
+    def track_channel(self):
+        # Keep track of channel name changes, deletion, creation
+        def channel_resolver(channels, channel, ident):            
+            def name_exist(channels, name):
+                if name == '':
+                    return False
+                
+                if name == False:
+                    return False
+    
+                for obj in channels:
+                    if channels[obj]['name'] == name:
+                        return channels[obj]
+                return False
+    
+            def id_exist(channels, ident):
+                if ident == '':
+                    return False
+    
+                if ident == False:
+                    return False
+    
+                if ident in channels:
+                    return channels[ident]
+                else:
+                    return False
+                
+            cname, cid = name_exist(channels, channel), id_exist(channels, ident)
+            if cname and not cid:
+                return 'resolved_id', cname['name'], cname['channel_id']
+            elif not cname and cid:
+                return 'resolved_name', cid['name'], cid['channel_id']
+            elif cname and cid:
+                if (cname['name'] == cid['name']) and (cname['channel_id'] == cid['channel_id']):
+                    return 'ok', cname['name'], cname['channel_id']
+            elif not cname and not cid:               
+                return 'removed', False, False
+
+        status, channel, channel_id = channel_resolver(self.bot.mumble.channels, self.rss_channel, self.rss_channel_id)
+        if status == 'resolved_id':
+            self.rss_channel_id = channel_id
+            self.config.set('config','rss_channel_id',str(channel_id))
+            self.save_config()
+            return True
+        elif status == 'resolved_name':
+            self.rss_channel = channel
+            self.config.set('config','rss_channel', channel)
+            self.save_config()
+            return True
+        elif status == 'removed':
+            if self.rss_channel_id != '':
+                self.rss_channel_id = channel_id
+                self.config.set('config','rss_channel_id', '')
+                self.save_config()
+            return False
+        elif status == 'ok':
+            return True
+
+    def task_rss(self, state):
+        self.bot.log.debug(f'task_rss: initialized...')
+
+        while True:
+            try:
+                if state[0] == util.TaskState.started:
+                    self.bot.log.debug(f'task_rss: idle, waiting for release...')
+                elif state[0] == util.TaskState.released:
+                    if self.checkrss:
+                        if self.track_channel():
+                            if self.get_feeds():                                
+                                self.send_feed()
+                    else:
+                        state[0] = util.TaskState.paused
+                elif state[0] == util.TaskState.paused:
+                    self.bot.log.debug(f'task_rss: idle/paused, waiting for release')
+                    # Resume requests by command
+                    if self.checkrss:
+                        state[0] = util.TaskState.released
+                else:
+                    self.bot.log.debug(f'task_rss: ending...')
+                    state[0] = util.TaskState.stopped
+                    break
+            except Exception as loop_error:
+                self.bot.log.debug(f'task_rss: exception:\n {loop_error}')
+                state[0] = util.TaskState.stopped
+                break
+            time.sleep(self.interval*60)
+
+    def load_config(self):
+        cfgdef = 'local-lib/rsslib/libconfiguration.default.ini'
+        self.cfg = 'local-lib/rsslib/libconfiguration.ini'
+        self.config = configparser.ConfigParser(interpolation=None, allow_no_value=True)
+        parsed_configs = self.config.read([util.solve_filepath(cfgdef), util.solve_filepath(self.cfg)],
+                                      encoding='utf-8')
+        if len(parsed_configs) == 0:
+            self.bot.log.error(f'load_config: Could not read configuration from {self.cfg}')
+
+        self.autostart = self.config.getboolean('config','autostart')
+        self.rss_channel = self.config.get('config','rss_channel')
+        if self.rss_channel == '':
+            self.bot.log.info(f'\n[RSSLib] rss_channel not set in libconfiguration.ini')
+        self.checkrss = self.autostart
+
+        # Obtain integer from configuration string
+        try:
+            self.rss_channel_id = self.config.getint('config','rss_channel_id')
+        except ValueError:
+            self.rss_channel_id = ''
+
+        self.rss_url = self.config.get('feeds','rssfeed')
+        self.previous_entry = self.config.get('feeds','previous_entry')
+        self.interval = self.config.getint('feeds','interval_mins')
+        self.subbed_users = json.loads(self.config.get('subscriptions','subbed_users'))
+        self.bot.log.info(f'\n[RSSLib]\nfeed:\n\t{self.rss_url}\ninterval:\n\t{self.interval}mins.\nautostart:\n\t{self.autostart}')
+
+    def save_config(self):
+        with open(self.cfg, 'w') as configfile:
+            self.config.write(configfile)
+
+
+def load_mod(bot):
+    if feedparser is None:
+        raise NameError(f'rsslib.typical.loadmod: feedparser required, `venv/bin/python -m pip install feedparser`')
+    lib = RSSLib(bot)
+    lib_name=type(lib).__name__
+    bot.register_lib(lib_name=lib_name, handle=lib, route_map=route_map)
+
+    # Create rss task
+    task_name=lib.task_rss.__name__
+    bot.create_task(task_name, lib.task_rss)
+
+

--- a/local-lib/rsslib/rsslib/typ_rsslib.py
+++ b/local-lib/rsslib/rsslib/typ_rsslib.py
@@ -11,9 +11,14 @@ import util
 from constants import tr_lib as trl, tr_cli as tr
 #import variables as var
 
-
 # TODO:
-# commands(**kwargs) since __init__ self.bot
+# In order to get rid of another bot as being the argument at commands, a suggestion is to migrate old commands.
+# pack at mumbleBot.py.message_received / command_exc
+#    self.cmd_handle[command_exc]['handle'](self, user, text, command_exc, parameter)
+#                                       v
+#    self.cmd_handle[command_exc]['handle'](bot=self, user=user, text=text, command_exc=command_exc, parameter=parameter)
+#       - Requires modification typ_rssplugin.py commands for *args (to ignore it's bot object, since __init__ self.bot) *Example below @command('kwargs')
+#       - Requires modification of all existing command.py commands for dealing with *args (to still obtain that bot object)
 
 
 # Index module
@@ -38,7 +43,18 @@ class Rss():
         self.new_entries = {}
         self.queued_entries = []
         self.prev_hash = ''
-        
+
+    '''
+    @command('kwargs')
+    def cmd_test(self, **exhan):
+        # from commented self,bot.message_received
+        # (bot=self, user=user, text=text, command_exc=command_exc, parameter=parameter)
+        # Printing dictionary items
+        for key in exhan:
+            print("> %s = %s" % (key, exhan[key]))
+        self.bot.mumble.users[exhan['text'].actor].send_text_message(f'Kuwarug..')
+    '''
+
     @command('getrss', no_partial_match=False, admin=False)
     def cmd_getrss(self, bot, user, text, command, parameter):
         self.get_latest(skip_prev=True)
@@ -306,15 +322,16 @@ class Rss():
         with open(self.cfg, 'w') as configfile:
             self.config.write(configfile)
 
-    def task_rss(self):        
+    def task_rss(self):
         self.bot.log.debug(f'task_rss: initialized... ')
         time.sleep(2) # be patient
-        while True:            
-            try:                    
+        while True:
+            try:
                 if self.checkrss:
-                    if self.track_channel():
-                        if self.get_latest(skip_prev=False):
-                            self.send_feed()
+                    print('RSS ESCAPED')
+                    #if self.track_channel():
+                    #    if self.get_latest(skip_prev=False):
+                    #        self.send_feed()
                 else:
                     self.bot.log.debug(f'task_rss: paused...')
             except Exception as loop_error:

--- a/local-lib/rsslib/setup.cfg
+++ b/local-lib/rsslib/setup.cfg
@@ -1,0 +1,6 @@
+[metadata]
+name = local-rsslib
+version = 0.1.0
+
+[options]
+packages = rsslib

--- a/local-lib/rsslib/setup.py
+++ b/local-lib/rsslib/setup.py
@@ -1,0 +1,3 @@
+import setuptools
+
+setuptools.setup()

--- a/local_lib_pipinstal.sh
+++ b/local_lib_pipinstal.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+# 202001115
+
+venv/bin/python -m pip install -e local-lib/rsslib
+
+venv/bin/pip freeze

--- a/local_lib_pipuninstal.sh
+++ b/local_lib_pipuninstal.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+# 202001115
+
+venv/bin/pip uninstall local-rsslib
+
+

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -253,15 +253,14 @@ class MumbleBot:
 
     def register_command(self, cmd, handle, no_partial_match=False, access_outside_channel=False, admin=False):
         cmds = cmd.split(",")
-        command = 'dd'
-        for command in cmds:
-            command = command.strip()
-            if command:
-                self.cmd_handle[command] = {'handle': handle,
+        for cmd in cmds:
+            cmd = cmd.strip()
+            if cmd:
+                self.cmd_handle[cmd] = {'handle': handle,
                                             'partial_match': not no_partial_match,
                                             'access_outside_channel': access_outside_channel,
                                             'admin': admin}
-                self.log.debug(f'bot: command added: {command}')
+                self.log.debug(f'bot: command added: {cmd}')
 
     def set_comment(self):
         self.mumble.users.myself.comment(var.config.get('bot', 'comment'))

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -360,6 +360,7 @@ class MumbleBot:
                     return
 
                 self.cmd_handle[command_exc]['handle'](self, user, text, command_exc, parameter)
+                #self.cmd_handle[command_exc]['handle'](bot=self, user=user, text=text, command_exc=command_exc, parameter=parameter)
             except:
                 error_traceback = traceback.format_exc()
                 error = error_traceback.rstrip().split("\n")[-1]

--- a/util.py
+++ b/util.py
@@ -17,6 +17,7 @@ from sys import platform
 import traceback
 import requests
 from packaging import version
+from enum import Enum
 
 log = logging.getLogger("bot")
 
@@ -521,3 +522,21 @@ class VolumeHelper:
 
         # Some dirty trick to stretch the function, to make to be 0 when input is -35 dB
         return (10 ** (dB / 20) - 10 ** (-35 / 20)) / (1 - 10 ** (-35 / 20))
+
+
+class TaskState(Enum):
+    added = 0
+    started = 1
+    released = 2
+    paused = 3
+    stopped = 4
+    
+    
+class TaskHandle:
+    def __init__(self, name, state, handle):
+        self.name = name
+        self.state = [TaskState.added] # using list as mutable wrapper
+        self.handle = handle
+        self.thread = None
+        
+

--- a/util.py
+++ b/util.py
@@ -17,7 +17,8 @@ from sys import platform
 import traceback
 import requests
 from packaging import version
-from enum import Enum
+import threading
+
 
 log = logging.getLogger("bot")
 
@@ -524,19 +525,13 @@ class VolumeHelper:
         return (10 ** (dB / 20) - 10 ** (-35 / 20)) / (1 - 10 ** (-35 / 20))
 
 
-class TaskState(Enum):
-    added = 0
-    started = 1
-    released = 2
-    paused = 3
-    stopped = 4
-    
-    
 class TaskHandle:
-    def __init__(self, name, state, handle):
+    def __init__(self, name, handle):
         self.name = name
-        self.state = [TaskState.added] # using list as mutable wrapper
         self.handle = handle
-        self.thread = None
-        
+        thnm = f"Task{name.replace('task_', '').capitalize()}Thread"
+        self.thread = threading.Thread(
+                    target=handle, name=thnm)
+        self.thread.daemon = True
+
 


### PR DESCRIPTION
**Basic loader for local libraries with optional looping tasks**.

- Custom libraries placed in the  _local-lib_ folder(configuration.default.ini) can be installed as in example "local_lib_pipinstal.sh" with:
venv/bin/python -m pip install -e local-lib/testlib
As it will be installed as *.egg-link in venv/../../site-packages, updating is a matter of updating the files in local-lib folder.
- list with libs to be loaded in configuration.default.ini
- lib has it's own libconfiguration.ini
- lib has it's own lang translation files *example lib holds help message(!test command only) that extend the main help string.
- No lib reload(just restart bot)
- No auto dependency install(TestLib performs one basic check on it's own for _feedparser_ example), need to figure out if/how to have those installed by the setup files