### PR TITLE
Allow music_folder to not have trailing /

### DIFF
--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -821,6 +821,9 @@ if __name__ == '__main__':
     DatabaseMigration(var.db, var.music_db).migrate()
 
     var.music_folder = util.solve_filepath(var.config.get('bot', 'music_folder'))
+    if not var.music_folder.endswith(os.sep):
+        # The file searching logic assumes that the music folder ends in a /
+        var.music_folder = var.music_folder + os.sep
     var.tmp_folder = util.solve_filepath(var.config.get('bot', 'tmp_folder'))
 
     # ======================

--- a/util.py
+++ b/util.py
@@ -40,8 +40,6 @@ def get_recursive_file_list_sorted(path):
         relroot = root.replace(path, '', 1)
         if relroot != '' and relroot in var.config.get('bot', 'ignored_folders'):
             continue
-        if len(relroot):
-            relroot += '/'
         for file in files:
             if file in var.config.get('bot', 'ignored_files'):
                 continue


### PR DESCRIPTION
Any path portion listed in `os.path.join()` is an absolute path (i.e. starts with `/`), all previous parts are ignored (https://docs.python.org/3/library/os.path.html#os.path.join). The way the recursive file search works currently, requires the `music_folder` to have a trailing `/` to ensure that `relpath` doesn't start with one. This patch removes that requirement by including a trailing path separator if one is not provided in the config