### PR TITLE
add support for setting bot bandwidth

### DIFF
--- a/configuration.default.ini
+++ b/configuration.default.ini
@@ -32,6 +32,8 @@ comment = "Hi, I'm here to play radio, local music or youtube/soundcloud music. 
 # default volume from 0 to 1.
 volume = 0.1
 stereo = True
+# bandwidth used by the bot
+bandwidth = 200000
 # playback mode should be one of "one-shot", "repeat", "random", "autoplay"
 playback_mode = one-shot
 autoplay_length = 5

--- a/configuration.default.ini
+++ b/configuration.default.ini
@@ -33,7 +33,7 @@ comment = "Hi, I'm here to play radio, local music or youtube/soundcloud music. 
 volume = 0.1
 stereo = True
 # bandwidth used by the bot
-bandwidth = 200000
+bandwidth = 96000
 # playback mode should be one of "one-shot", "repeat", "random", "autoplay"
 playback_mode = one-shot
 autoplay_length = 5

--- a/configuration.example.ini
+++ b/configuration.example.ini
@@ -49,6 +49,11 @@ port = 64738
 # This option will be overridden by value in the database.
 #volume = 0.1
 
+# 'bandwidth' is the number of bits per second used by the bot when streaming audio. Enabling this
+#    option will allow you to set it higher than the default value. If the value exceeds the servers
+#    bitrate, the bitrate used by the bot will match the servers.
+#bandwidth = 200000
+
 # 'playback_mode' defined the playback mode of the bot.
 #    it should be one of "one-shot" (remove item once played), "repeat" (looping through the playlist),
 #    or "random" (randomize the playlist), "autoplay" (randomly grab something from the music library).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,6 +41,10 @@ if [ -n "$BAM_VERBOSE" ]; then
     command+=( "--verbose" )
 fi
 
+if [ -n "$BAM_BANDWIDTH" ]; then
+    command+=( "--bandwidth" )
+fi
+
 if [ -n "$BAM_CONFIG_file" ]; then
     if [ ! -f "$BAM_CONFIG_file" ]; then
         cp "/botamusique/configuration.example.ini" "$BAM_CONFIG_file"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ if [ -n "$BAM_VERBOSE" ]; then
 fi
 
 if [ -n "$BAM_BANDWIDTH" ]; then
-    command+=( "--bandwidth" )
+    command+=( "--bandwidth" "$BAM_BANDWIDTH")
 fi
 
 if [ -n "$BAM_CONFIG_file" ]; then

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -108,6 +108,11 @@ class MumbleBot:
         else:
             self.username = var.config.get("bot", "username")
 
+        if args.bandwidth:
+            self.bandwidth = args.bandwidth
+        else:
+            self.bandwidth = var.config.get("bot", "bandwidth")
+
         self.mumble = pymumble.Mumble(host, user=self.username, port=port, password=password, tokens=tokens,
                                       stereo=self.stereo,
                                       debug=var.config.getboolean('debug', 'mumbleConnection'),
@@ -124,7 +129,7 @@ class MumbleBot:
         self.set_comment()
         self.mumble.users.myself.unmute()  # by sure the user is not muted
         self.join_channel()
-        self.mumble.set_bandwidth(200000)
+        self.mumble.set_bandwidth(self.bandwidth)
 
         # ====== Volume ======
         self.volume_helper = util.VolumeHelper()
@@ -759,6 +764,8 @@ if __name__ == '__main__':
                         type=str, help="Default channel for the bot")
     parser.add_argument("-C", "--cert", dest="certificate",
                         type=str, default=None, help="Certificate file")
+    parser.add_argument("-b", "--bandwidth", dest="bandwidth",
+                        type=int, help="Bandwidth used by the bot")
 
     args = parser.parse_args()
 

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -111,7 +111,7 @@ class MumbleBot:
         if args.bandwidth:
             self.bandwidth = args.bandwidth
         else:
-            self.bandwidth = var.config.get("bot", "bandwidth")
+            self.bandwidth = var.config.getint("bot", "bandwidth")
 
         self.mumble = pymumble.Mumble(host, user=self.username, port=port, password=password, tokens=tokens,
                                       stereo=self.stereo,


### PR DESCRIPTION
This PR is aimed at resolving #62 
Added support to the configuration file and arguments passed allowing users to specify the bots bandwidth usage. Prior to this PR I built it on docker and successfully was able to deploy it to the server. I have yet to test it with pure arguments.