### PR TITLE
Improve robustness of command parsing

### DIFF
--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -252,20 +252,16 @@ class MumbleBot:
             # you want to split the username
             user = user.split()[0]
 
-        if message.startswith(tuple(var.config.get('commands', 'command_symbol'))):
-            # remove the symbol from the message
-            message = message[1:].split(' ', 1)
+        command_symbols = var.config.get('commands', 'command_symbol')
+        match = re.match(fr'^[{re.escape(command_symbols)}](?P<command>\S+)(?:\s(?P<argument>.*))?', message)
+        if match:
+            command = match.group("command").lower()
+            argument = match.group("argument")
 
-            # use the first word as a command, the others one as  parameters
-            if len(message) > 0:
-                command = message[0].lower()
-                parameter = ''
-                if len(message) > 1:
-                    parameter = message[1].rstrip()
-            else:
+            if not command:
                 return
 
-            self.log.info('bot: received command ' + command + ' - ' + parameter + ' by ' + user)
+            self.log.info(f'bot: received command "{command}" with arguments "{argument}" from {user}')
 
             # Anti stupid guy function
             if not self.is_admin(user) and not var.config.getboolean('bot', 'allow_private_message') and text.session:
@@ -279,8 +275,8 @@ class MumbleBot:
                         tr('user_ban'))
                     return
 
-            if not self.is_admin(user) and parameter:
-                input_url = util.get_url_from_input(parameter)
+            if not self.is_admin(user) and argument:
+                input_url = util.get_url_from_input(argument)
                 if input_url and var.db.has_option('url_ban', input_url):
                     self.mumble.users[text.actor].send_text_message(
                         tr('url_ban'))
@@ -323,7 +319,7 @@ class MumbleBot:
                         tr('not_in_my_channel'))
                     return
 
-                self.cmd_handle[command_exc]['handle'](self, user, text, command_exc, parameter)
+                self.cmd_handle[command_exc]['handle'](self, user, text, command_exc, argument)
             except:
                 error_traceback = traceback.format_exc()
                 error = error_traceback.rstrip().split("\n")[-1]

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -256,7 +256,7 @@ class MumbleBot:
         match = re.match(fr'^[{re.escape(command_symbols)}](?P<command>\S+)(?:\s(?P<argument>.*))?', message)
         if match:
             command = match.group("command").lower()
-            argument = match.group("argument")
+            argument = match.group("argument") or ""
 
             if not command:
                 return


### PR DESCRIPTION
This migrates the command parsing from an index and text splitting based
approach to a regular expression, making it more robust in the process.

Also renames parameter to argument, because parameters have a key/value
relationship while arguments do not.

---

The regular expression can be separated into three logical parts:
- the character class of command symbols, escaped using `re.escape`, so there will be no special meaning to characters like dot
- the match group command, that matches everything until the first whitespace
- the match group argument that matches everything after the first whitespace, defaults to `None` if not matched

We could also precompile the pattern, if anyone worries about performance.

<s>This change uses the walrus operator, introduced in Python 3.8. I couldn't find a supported version range, so I hope this is fine.</s>

Tested on my local instance and works as expected.