### PR TITLE
Allow changing bot avatar

### DIFF
--- a/configuration.default.ini
+++ b/configuration.default.ini
@@ -29,6 +29,7 @@ certificate =
 [bot]
 username = botamusique
 comment = "Hi, I'm here to play radio, local music or youtube/soundcloud music. Have fun!"
+avatar =
 # default volume from 0 to 1.
 volume = 0.1
 stereo = True

--- a/configuration.example.ini
+++ b/configuration.example.ini
@@ -21,8 +21,10 @@ port = 64738
 [bot]
 # 'username' is the user name of the bot.
 # 'comment' is the comment displayed by the bot.
+# 'avatar' is the path to the avatar image shown on the bot (PNG recommended, 128 KB max).
 #username = botamusique
 #comment = "Hi, I'm here to play radio, local music or youtube/soundcloud music. Have fun!"
+#avatar =
 
 # 'language': Available languages can be found inside lang/ folder.
 #language=en_US

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -127,6 +127,7 @@ class MumbleBot:
             exit()
 
         self.set_comment()
+        self.set_avatar()
         self.mumble.users.myself.unmute()  # by sure the user is not muted
         self.join_channel()
         self.mumble.set_bandwidth(self.bandwidth)
@@ -232,6 +233,15 @@ class MumbleBot:
 
     def set_comment(self):
         self.mumble.users.myself.comment(var.config.get('bot', 'comment'))
+
+    def set_avatar(self):
+        avatar_path = var.config.get('bot', 'avatar', fallback=None)
+
+        if avatar_path:
+            with open(avatar_path, 'rb') as avatar_file:
+                self.mumble.users.myself.texture(avatar_file.read())
+        else:
+            self.mumble.users.myself.texture(b'')
 
     def join_channel(self):
         if self.channel:


### PR DESCRIPTION
This PR adds an `avatar` option to the config file. The option specifies the path to an image that the bot will use as its avatar on the Mumble server.

Note: The comment added to the example config points out a limit of 128 KB for the avatar image, but I think this limit is adjustable using the `imagemessagelength` option in the Murmur configuration. I'm also not completely sure which file formats are supported by Mumble, but PNG seems to work.

Additionally, this setting is currently completely independent from the image shown on the Flask web interface. If a user wanted to change that image then I assume they would need to replace the appropriate file under /static/image.