### PR TITLE
fix(web): fix response to periodic POST requests

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -335,7 +335,7 @@ def status():
 def post():
     global log
 
-    payload = request.form if request.form else request.json
+    payload = request.get_json() if request.is_json else request.form
     if payload:
         log.debug("web: Post request from %s: %s" % (request.remote_addr, str(payload)))
 


### PR DESCRIPTION
The reason POST requests were being responded to with 400 is that in the assignment of payload, the request.json member is used if request.form evaluates as false, but accessing request.json results in an error for some requests, even though flask docs claim that the value will simply be `None`.

resolves #339