### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /botamusique
 
 RUN apt-get update \
-    && apt-get install -y gcc g++ ffmpeg libjpeg-dev libmagic-dev opus-tools zlib1g-dev \
+    && apt-get install --no-install-recommends -y gcc g++ ffmpeg libjpeg-dev libmagic-dev opus-tools zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 COPY . /botamusique
 
@@ -16,7 +16,7 @@ FROM python:3-slim-bullseye
 ENV DEBIAN_FRONTEND noninteractive
 EXPOSE 8181
 RUN apt update && \
-    apt install -y opus-tools ffmpeg libmagic-dev curl tar && \
+    apt install --no-install-recommends -y opus-tools ffmpeg libmagic-dev curl tar && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=python-builder /botamusique /botamusique
 WORKDIR /botamusique


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

The change I made:
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.

Impact on the image size:
* Image size before repair: 667 MB
* Image size after repair: 581.6 MB
* Difference: 85.4 MB (12.8%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,