### PR TITLE
HTTPS Support

### DIFF
--- a/configuration.default.ini
+++ b/configuration.default.ini
@@ -80,6 +80,8 @@ password =
 upload_enabled = True
 user =
 web_logfile =
+websslkey =
+websslcert  =
 
 [debug]
 ffmpeg = False

--- a/configuration.default.ini
+++ b/configuration.default.ini
@@ -80,8 +80,9 @@ password =
 upload_enabled = True
 user =
 web_logfile =
-websslkey =
-websslcert  =
+ssl_enabled = False
+ssl_cert =
+ssl_key  =
 
 [debug]
 ffmpeg = False

--- a/configuration.example.ini
+++ b/configuration.example.ini
@@ -180,6 +180,11 @@ port = 64738
 #upload_enabled = True
 #max_upload_file_size = 30MB
 
+#'websslcert', 'websslkey': If provided, the web interface is served over HTTPS.
+#
+#websslcert = /home/user/example/cert.pem
+#websslkey = /home/user/example/key.pem
+
 # [debug] stores some debug settings.
 [debug]
 #ffmpeg = False # Set ffmpeg to True if you want to display DEBUG level log of ffmpeg.

--- a/configuration.example.ini
+++ b/configuration.example.ini
@@ -146,13 +146,21 @@ port = 64738
 # 'enable': Set 'enabled' to True if you'd like to use the web interface to manage
 #     your playlist, upload files, etc.
 #     The web interface is disable by default for security and performance reason.
-# 'access_address': Used when user are questing the address to access the web interface.
+# 'access_address': Used when users are requesting the address to access the web interface.
 #enabled = False
 #listening_addr = 127.0.0.1
 #listening_port = 8181
 #is_web_proxified = True
 # This is the public URL
 #access_address = http://127.0.0.1:8181
+
+# 'ssl_enabled': Enable HTTPS support. You must provide an SSL certificate and keyfile
+# 'ssl_cert', 'ssl_key': If provided, the web interface is served over HTTPS.
+#                        Be sure to set your access_address to use https.
+#ssl_enabled = False
+#ssl_cert = /home/user/example/cert.pem
+#ssl_key = /home/user/example/key.pem
+#access_address = https://my.domain.org:8181
 
 # 'web_logfile': write access logs of the web server into this file.
 #web_logfile =
@@ -179,12 +187,6 @@ port = 64738
 # 'maximum_upload_file_size': Unit can be 'B', 'KB', 'MB', 'GB', 'TB'.
 #upload_enabled = True
 #max_upload_file_size = 30MB
-
-#'websslcert', 'websslkey': If provided, the web interface is served over HTTPS.
-#                           Be sure to set access_address to use https'.
-#access_address = https://my.domain.org:8181
-#websslcert = /home/user/example/cert.pem
-#websslkey = /home/user/example/key.pem
 
 # [debug] stores some debug settings.
 [debug]

--- a/configuration.example.ini
+++ b/configuration.example.ini
@@ -181,7 +181,9 @@ port = 64738
 #max_upload_file_size = 30MB
 
 #'websslcert', 'websslkey': If provided, the web interface is served over HTTPS.
+#                           Be sure to set access_address to https:
 #
+#access_address = https://my.domain.org:8181
 #websslcert = /home/user/example/cert.pem
 #websslkey = /home/user/example/key.pem
 

--- a/configuration.example.ini
+++ b/configuration.example.ini
@@ -154,12 +154,12 @@ port = 64738
 # This is the public URL
 #access_address = http://127.0.0.1:8181
 
-# 'ssl_enabled': Enable HTTPS support. You must provide an SSL certificate and keyfile
-# 'ssl_cert', 'ssl_key': If provided, the web interface is served over HTTPS.
+# 'ssl_enabled': Enable HTTPS support. You must provide an SSL certificate and keyfile.
+# 'ssl_cert', 'ssl_key': Path to your ssl certificate and keyfile.
 #                        Be sure to set your access_address to use https.
 #ssl_enabled = False
-#ssl_cert = /home/user/example/cert.pem
-#ssl_key = /home/user/example/key.pem
+#ssl_cert = /home/example/cert.pem
+#ssl_key = /home/example/key.pem
 #access_address = https://my.domain.org:8181
 
 # 'web_logfile': write access logs of the web server into this file.

--- a/configuration.example.ini
+++ b/configuration.example.ini
@@ -181,8 +181,7 @@ port = 64738
 #max_upload_file_size = 30MB
 
 #'websslcert', 'websslkey': If provided, the web interface is served over HTTPS.
-#                           Be sure to set access_address to https:
-#
+#                           Be sure to set access_address to use https'.
 #access_address = https://my.domain.org:8181
 #websslcert = /home/user/example/cert.pem
 #websslkey = /home/user/example/key.pem

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -32,7 +32,7 @@ from media.cache import MusicCache
 
 
 class MumbleBot:
-    version = 'git'
+    version = '7.2.2'
 
     def __init__(self, args):
         self.log = logging.getLogger("bot")
@@ -113,13 +113,6 @@ class MumbleBot:
         else:
             self.bandwidth = var.config.getint("bot", "bandwidth")
         
-        if args.websslkey and args.websslcert:
-            if str(args.websslkey) and str(args.websslcert):
-                self.websslkey = args.websslkey
-                self.websslcert = args.websslcert
-                self.sslenabled = True
-        else:
-            self.sslenabled = False
 
         self.mumble = pymumble.Mumble(host, user=self.username, port=port, password=password, tokens=tokens,
                                       stereo=self.stereo,
@@ -762,7 +755,7 @@ def start_web_interface(addr, port, **kwargs):
     interface.init_proxy()
     interface.web.env = 'development'
     interface.web.secret_key = var.config.get('webinterface', 'flask_secret')
-    if sslkey in kwargs.items() and sslcert in kwargs.items():
+    if var.config.getboolean("webinterface", "ssl_enabled"):
         interface.web.run(port=port, host=addr, ssl_context=(sslcert, sslkey))
     else:
         interface.web.run(port=port, host=addr)
@@ -951,9 +944,11 @@ if __name__ == '__main__':
     if var.config.getboolean("webinterface", "enabled"):
         wi_addr = var.config.get("webinterface", "listening_addr")
         wi_port = var.config.getint("webinterface", "listening_port")
-        if self.sslenabled:
+        if var.config.getboolean("webinterface", "ssl_enabled"):
+            wi_ssl_cert = var.config.get("webinterface", "ssl_cert")
+            wi_ssl_key = var.config.get("webinterface", "ssl_key")
             tt = threading.Thread(
-                target=start_web_interface, name="WebThread", args=(wi_addr, wi_port, sslcert=self.websslcert, sslkey=self.websslkey))
+                target=start_web_interface, name="WebThread", kwargs={'sslcert': wi_ssl_cert, 'sslkey': wi_ssl_key}, args=(wi_addr, wi_port))
         else:
             tt = threading.Thread(
                 target=start_web_interface, name="WebThread", args=(wi_addr, wi_port))

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -764,7 +764,8 @@ def start_web_interface(addr, port, **kwargs):
     interface.web.secret_key = var.config.get('webinterface', 'flask_secret')
     if sslkey in kwargs.items() and sslcert in kwargs.items():
         interface.web.run(port=port, host=addr, ssl_context=(sslcert, sslkey))
-    interface.web.run(port=port, host=addr)
+    else:
+        interface.web.run(port=port, host=addr)
 
 
 if __name__ == '__main__':

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -756,7 +756,7 @@ def start_web_interface(addr, port, **kwargs):
     interface.web.env = 'development'
     interface.web.secret_key = var.config.get('webinterface', 'flask_secret')
     if var.config.getboolean("webinterface", "ssl_enabled"):
-        interface.web.run(port=port, host=addr, ssl_context=(sslcert, sslkey))
+        interface.web.run(port=port, host=addr, ssl_context=(kwargs.get('sslcert'), kwargs.get('sslkey')))
     else:
         interface.web.run(port=port, host=addr)
 

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -32,7 +32,7 @@ from media.cache import MusicCache
 
 
 class MumbleBot:
-    version = '7.2.2'
+    version = 'git'
 
     def __init__(self, args):
         self.log = logging.getLogger("bot")
@@ -112,7 +112,6 @@ class MumbleBot:
             self.bandwidth = args.bandwidth
         else:
             self.bandwidth = var.config.getint("bot", "bandwidth")
-        
 
         self.mumble = pymumble.Mumble(host, user=self.username, port=port, password=password, tokens=tokens,
                                       stereo=self.stereo,

--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -947,7 +947,7 @@ if __name__ == '__main__':
             wi_ssl_cert = var.config.get("webinterface", "ssl_cert")
             wi_ssl_key = var.config.get("webinterface", "ssl_key")
             tt = threading.Thread(
-                target=start_web_interface, name="WebThread", kwargs={'sslcert': wi_ssl_cert, 'sslkey': wi_ssl_key}, args=(wi_addr, wi_port))
+                target=start_web_interface, name="WebThread", args=(wi_addr, wi_port), kwargs={'sslcert': wi_ssl_cert, 'sslkey': wi_ssl_key})
         else:
             tt = threading.Thread(
                 target=start_web_interface, name="WebThread", args=(wi_addr, wi_port))


### PR DESCRIPTION
While setting up botamusique on my own mumble server, I made a few small changes which allowed me to serve the webpage over HTTPS with a ssl certificate and keyfile for my domain.

I thought it would be cool to add this as an option in the configuration file and raise a PR.

What I did was modify the start_web_interface function to accept optional keyword arguments (sslcert and sslkey).
If the user enables SSL support in the config file and provides a path to the key and cert, then start_web_interface will feed the provided filepaths to the web interface using the ssl_context kwarg.

Any feedback is welcome.