### PR TITLE
Fix an option, cleanup typos & wording.

### DIFF
--- a/configuration.default.ini
+++ b/configuration.default.ini
@@ -4,7 +4,7 @@
 # ========================================================
 #  WARNING:
 #           ******************************
-#           **DO NOT MODIFIED THIS FILE.**
+#           ** DO NOT MODIFY THIS FILE. **
 #           ******************************
 #
 #           Please create your own configuration file, and

--- a/configuration.example.ini
+++ b/configuration.example.ini
@@ -61,7 +61,7 @@ port = 64738
 #    or "random" (randomize the playlist), "autoplay" (randomly grab something from the music library).
 #    This option will be overridden by value in the database.
 # 'autoplay_length': how many songs the autoplay mode fills the playlist
-# 'clear_when_stop_in_oneshot': clear the playlist when stop the bot in one-shot mode.
+# 'clear_when_stop_in_oneshot': clear the playlist when stopping the bot in one-shot mode.
 #playback_mode = one-shot
 #autoplay_length = 5
 #clear_when_stop_in_oneshot = False
@@ -98,7 +98,7 @@ port = 64738
 # 'delete_allowed': Allow users to delete a file from the library (hard disk).
 #    Works both for command and web interface. After enabling this option, only
 #    admins are allowed to delete files.
-#delete_allowded = True
+#delete_allowed = True
 
 # 'save_music_library': If this is set True, the bot will save the metadata of music into the database.
 #save_music_library = True
@@ -145,8 +145,8 @@ port = 64738
 [webinterface]
 # 'enable': Set 'enabled' to True if you'd like to use the web interface to manage
 #     your playlist, upload files, etc.
-#     The web interface is disable by default for security and performance reason.
-# 'access_address': Used when user are questing the address to access the web interface.
+#     The web interface is disabled by default for security and performance reasons.
+# 'access_address': Used when users are requesting the address to access the web interface.
 #enabled = False
 #listening_addr = 127.0.0.1
 #listening_port = 8181
@@ -170,7 +170,7 @@ port = 64738
 #user = botamusique
 #password = mumble
 
-# 'flask_secret': To use token, flask need a password to encrypt/sign cookies.
+# 'flask_secret': To use a token, flask needs a password to encrypt/sign cookies.
 #                 !! YOU NEED TO CHANGE IT IF auth_method IS 'token'!!
 # flask_secret = ChangeThisPassword
 
@@ -188,11 +188,10 @@ port = 64738
 
 # [radio] is a list of default radio stations.
 [radio]
-# List of radio you want to have by default
-# one line by entrie
+# List of radio you want to have by default, one entry per line.
 #jazz = http://jazz-wr04.ice.infomaniak.ch/jazz-wr04-128.mp3 "Jazz Yeah !"
 
-# [youtube_dl] are option to custom youtube-dl (optionnal)
+# [youtube_dl] are options to customize youtube-dl (optional)
 [youtube_dl]
 # source_address , use '::' to force ipv6, "0.0.0.0" to force ipv4, or put the ip addresse you want to use.
 # source_address = '::'
@@ -201,7 +200,7 @@ port = 64738
 # user-agent allow the user to force the user-agent of youtube-dl
 # user-agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:87.0) Gecko/20100101 Firefox/87.0"
 
-# [commands] is settings related to user command sent via mumble message.
+# [commands] are settings related to user command sent via mumble message.
 [commands]
 # 'command_symbol' is a list of characters the bot recognizes as command prefix.
 #command_symbol = !:！


### PR DESCRIPTION
Fixed an option with a broken name (delete_allowded -> delete_allowed), various typos and improved wording in the configuration files.

The formatting was a bit weird as sometimes option names would start 
`"# option"`
 and sometimes 
`"#option"`
but I didn't choose to act on those.

Compiled the project succesfully and found no run-time issues.