### PR TITLE
Properly fix version handling with packaging>=22.0

### DIFF
--- a/mumbleBot.py
+++ b/mumbleBot.py
@@ -195,12 +195,14 @@ class MumbleBot:
             th.start()
 
         last_startup_version = var.db.get("bot", "version", fallback=None)
-        if self.version != "git":
+        try:
             if not last_startup_version or version.parse(last_startup_version) < version.parse(self.version):
                 var.db.set("bot", "version", self.version)
                 if var.config.getboolean("bot", "auto_check_update"):
                     changelog = util.fetch_changelog()
                     self.send_channel_msg(tr("update_successful", version=self.version, changelog=changelog))
+        except version.InvalidVersion:
+            var.db.set("bot", "version", self.version)
 
     # Set the CTRL+C shortcut
     def ctrl_caught(self, signal, frame):


### PR DESCRIPTION
Both the current version and the last startup version can be unparsable.

Hence we now just catch the resulting exception and reset the version
to the new version, which may or may not be parsable, which we'll find
out on the next start up. But either way this prevents crashes from
unparsable versions in the database.

This is a follow-up for https://github.com/azlux/botamusique/commit/eb4c63db8957aca2bde93b593a2109acf0ea6a1c.
