### PR TITLE
fix: util: clear_tmp_folder: exclude invalid symlinks

### DIFF
--- a/util.py
+++ b/util.py
@@ -547,6 +547,8 @@ def clear_tmp_folder(path, size):
             all_files = ""
             for (path, dirs, files) in os.walk(path):
                 all_files = [os.path.join(path, file) for file in files]
+                # exclude invalid symlinks (linux)
+                all_files = [file for file in all_files if os.path.exists(file)]
                 all_files.sort(key=lambda x: os.path.getmtime(x))
             size_tp = 0
             for idx, file in enumerate(all_files):


### PR DESCRIPTION
**!yplay** command on *Ubuntu* throws *FileNotFound* trying to check *path.getmtime* on invalid symlink in *temp* folder.

```bash
[May 30 11:30:14 INFO] bot: start preparing item in thread: [url] super title (https://www.youtube.com/watch?v=some_id)
Exception in thread Prepare-e507ebe:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/media/kac-/help2/src/botamusique/mumbleBot.py", line 484, in _download
    item.prepare()
  File "/media/kac-/help2/src/botamusique/media/cache.py", line 164, in prepare
    ret = self.item().prepare()
  File "/media/kac-/help2/src/botamusique/media/url.py", line 122, in prepare
    return self._download()
  File "/media/kac-/help2/src/botamusique/media/url.py", line 163, in _download
    util.clear_tmp_folder(var.tmp_folder, var.config.getint('bot', 'tmp_folder_max_size'))
  File "/media/kac-/help2/src/botamusique/util.py", line 550, in clear_tmp_folder
    all_files.sort(key=lambda x: os.path.getmtime(x))
  File "/media/kac-/help2/src/botamusique/util.py", line 550, in <lambda>
    all_files.sort(key=lambda x: os.path.getmtime(x))
  File "/usr/lib/python3.10/genericpath.py", line 55, in getmtime
    return os.stat(filename).st_mtime
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/.org.chromium.Chromium.Ce6hQK/SingletonCookie'
```