### PR TITLE
Fix `ytsearch -n' next page issue (#373)

### DIFF
--- a/command.py
+++ b/command.py
@@ -1172,6 +1172,7 @@ def cmd_shortlist(bot, user, text, command, parameter):
 
     bot.send_msg(tr('bad_parameter', command=command), text)
 
+
 def cmd_delete_from_library(bot, user, text, command, parameter):
     global song_shortlist, log
 

--- a/command.py
+++ b/command.py
@@ -567,7 +567,7 @@ def cmd_yt_search(bot, user, text, command, parameter):
                 song_shortlist = [{'type': 'url',
                                    'url': "https://www.youtube.com/watch?v=" + result[0],
                                    'title': result[1]
-                                   } for result in yt_last_result[yt_last_page * item_per_page: item_per_page]]
+                                   } for result in yt_last_result[yt_last_page * item_per_page: (yt_last_page * item_per_page) + item_per_page]]
                 msg = _yt_format_result(yt_last_result, yt_last_page * item_per_page, item_per_page)
                 bot.send_msg(tr('yt_result', result_table=msg), text)
             else:
@@ -1171,7 +1171,6 @@ def cmd_shortlist(bot, user, text, command, parameter):
             return
 
     bot.send_msg(tr('bad_parameter', command=command), text)
-
 
 def cmd_delete_from_library(bot, user, text, command, parameter):
     global song_shortlist, log


### PR DESCRIPTION
Fix an issue which caused the `ytsearch' to improperly fill the shortlist when used with `-p' to query the next search page.